### PR TITLE
Fix: 2차 마이페이지 및 큐레이션 QA 완료 후 추가 문제 개선

### DIFF
--- a/HaruUp/Component/DropDownView/DropDownView.swift
+++ b/HaruUp/Component/DropDownView/DropDownView.swift
@@ -16,6 +16,9 @@ final class DropdownView: UIView {
     private var items: [DropdownDisplayable] = []
     private var selectedId: Int?
     
+    // 셀 높이 상수 정의 (55pt로 통일)
+    private let rowHeight: CGFloat = 55.0
+    
     private let tableView: UITableView = {
         let tv = UITableView()
         tv.register(DropdownCell.self, forCellReuseIdentifier: "DropdownCell")
@@ -59,12 +62,14 @@ final class DropdownView: UIView {
         self.selectedId = selectedId
         self.tableView.reloadData()
         
+        // 스크롤 가능 여부 설정 (4개 초과일 때만 스크롤)
+        self.tableView.isScrollEnabled = items.count > 4
+        
         // 1. 높이 계산 (셀 높이 55pt 기준)
-        let rowHeight: CGFloat = 55.0
         let contentHeight = CGFloat(items.count) * rowHeight
         
         // 4개까지 보이도록 최대 높이를 220으로 설정 (55 * 4 = 220)
-        let maxHeight: CGFloat = 220.0
+        let maxHeight: CGFloat = rowHeight * 4
         
         // 실제 적용할 높이
         let finalHeight = min(contentHeight, maxHeight)
@@ -72,13 +77,7 @@ final class DropdownView: UIView {
         // 2. 높이 제약조건 업데이트
         if let heightConstraint = self.constraints.first(where: { $0.firstAttribute == .height }) {
             heightConstraint.constant = finalHeight
-            
-//            UIView.animate(withDuration: 0.3) {
-//                self.superview?.layoutIfNeeded()
-            //            }
-            heightConstraint.constant = finalHeight
-            // 필요하다면 레이아웃 갱신을 즉시 수행 (애니메이션 없이)
-            self.superview?.layoutIfNeeded()
+            self.superview?.layoutIfNeeded() // 즉시 반영
         }
         
         // 3. 내용이 220보다 길면 스크롤 바 깜빡임
@@ -87,6 +86,11 @@ final class DropdownView: UIView {
                 self.tableView.flashScrollIndicators()
             }
         }
+//        if items.count > 4 {
+//            DispatchQueue.main.async {
+//                self.tableView.flashScrollIndicators()
+//            }
+//        }
     }
 }
 
@@ -110,6 +114,6 @@ final class DropdownView: UIView {
         }
         
         func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-            return 48
+            return rowHeight
         }
     }

--- a/HaruUp/Network/Service/Interests/InterestsService.swift
+++ b/HaruUp/Network/Service/Interests/InterestsService.swift
@@ -178,7 +178,15 @@ final class InterestsService: Service {
                         single(.success(()))
                         print("📥 관심사 수정 응답: \(value)")
                     case .failure(let error):
-                        print("❌ 요청 실패: \(error.localizedDescription)")
+                        print("❌ 요청 실패 (Code: \(response.response?.statusCode ?? 0))")
+                        
+                        // 서버가 보낸 에러 메시지 출력 (이걸 봐야 원인을 알 수 있습니다!)
+                        if let data = response.data, let serverMessage = String(data: data, encoding: .utf8) {
+                            print("📝 [서버 에러 사유]: \(serverMessage)")
+                        } else {
+                            print("📝 서버 에러 메시지 없음")
+                        }
+                        
                         single(.failure(error))
                     }
                 }

--- a/HaruUp/Presentation/Curation/GoalInputSelect/GoalInputSelectViewController.swift
+++ b/HaruUp/Presentation/Curation/GoalInputSelect/GoalInputSelectViewController.swift
@@ -118,6 +118,7 @@ class GoalInputSelectViewController: UIViewController {
     private let textField: UITextField = {
         let tf = UITextField()
         tf.placeholder = "2~20자로 입력해주세요."
+        tf.setPlaceholder(color: .neutral300)
         tf.font = UIFont.pretendard(size: 16, weight: .medium)
         tf.textColor = .black
         tf.borderStyle = .none
@@ -610,7 +611,7 @@ class GoalInputSelectViewController: UIViewController {
         remainingSeconds = 30 * 60
         
         nextButton.isEnabled = false
-        nextButton.setImage(UIImage(named: "next_btn_gray"), for: .normal)
+        nextButton.backgroundColor = .neutral200
         textField.isEnabled = false
         
         updateWarningLabelWithTimer()

--- a/HaruUp/Presentation/Curation/GoalInputSelect/GoalInputSelectViewController.swift
+++ b/HaruUp/Presentation/Curation/GoalInputSelect/GoalInputSelectViewController.swift
@@ -508,10 +508,11 @@ class GoalInputSelectViewController: UIViewController {
                 guard let self = self else { return }
                 // 타이머가 작동 중이면 버튼은 항상 비활성화
                 if self.remainingSeconds > 0 {
-                    self.nextButton.setImage(UIImage(named: "next_btn_gray"), for: .normal)
+                    self.nextButton.backgroundColor = .neutral200
+                                        self.nextButton.isEnabled = false
                 } else {
-                    let imageName = isValid ? "next_btn_blue" : "next_btn_gray"
-                    self.nextButton.setImage(UIImage(named: imageName), for: .normal)
+                    self.nextButton.backgroundColor = isValid ? .cta : .neutral200
+                                        self.nextButton.isEnabled = isValid
                 }
             })
             .disposed(by: disposeBag)
@@ -528,7 +529,7 @@ class GoalInputSelectViewController: UIViewController {
             }
             .distinctUntilChanged()
             .subscribe(onNext: { [weak self] hasText in
-                self?.nextButton.isEnabled = hasText
+                
             })
             .disposed(by: disposeBag)
         
@@ -544,12 +545,12 @@ class GoalInputSelectViewController: UIViewController {
                     self.invalidAttemptCount = 0 // 성공 시 카운트 초기화
                     
                 case .empty:
-                    self.nextButton.setImage(UIImage(named: "next_btn_gray"), for: .normal)
+                    self.nextButton.backgroundColor = .neutral200
                     
                 case .tooShort:
                     self.warningLabel.setStyle(Typography.body4, text: "*2자 이상으로 입력해주세요.")
                     self.warningLabel.isHidden = false
-                    self.nextButton.setImage(UIImage(named: "next_btn_gray"), for: .normal)
+                    self.nextButton.backgroundColor = .neutral200
                     
 //                case .tooLong:
 //                    self.warningLabel.setStyle(Typography.body4, text: "*20자 이내로 입력해주세요.")
@@ -566,7 +567,7 @@ class GoalInputSelectViewController: UIViewController {
                     } else {
                         self.warningLabel.setStyle(Typography.body4, text: "*세부 관심사와 맞지 않는 목표예요.")
                         self.warningLabel.isHidden = false
-                        self.nextButton.setImage(UIImage(named: "next_btn_gray"), for: .normal)
+                        self.nextButton.backgroundColor = .neutral200
                     }
                 }
             })

--- a/HaruUp/Presentation/Curation/InterestDetailSelect/ForeignLanguageInputBottomSheet.swift
+++ b/HaruUp/Presentation/Curation/InterestDetailSelect/ForeignLanguageInputBottomSheet.swift
@@ -10,9 +10,21 @@ import RxSwift
 import RxCocoa
 
 class ForeignLanguageInputBottomSheet: UIViewController {
+    enum SheetType {
+        case curation   // 큐레이션 (처음 설정)
+        case edit       // 수정 (마이페이지)
+        
+        var buttonTitle: String {
+            switch self {
+            case .curation: return "다음"
+            case .edit: return "완료"
+            }
+        }
+    }
+    
+    private let sheetType: SheetType
     private let viewModel: ForeignLanguageInputBottomSheetViewModel
     private let disposeBag = DisposeBag()
-    
     
     // 완료 콜백
     var onFinish: ((String) -> Void)?
@@ -97,7 +109,6 @@ class ForeignLanguageInputBottomSheet: UIViewController {
     
     private let nextButton: UIButton = {
         let btn = UIButton()
-        btn.setTitle("다음", for: .normal)
         btn.titleLabel?.font = Typography.subtitle2.font
         btn.backgroundColor = .neutral200
         btn.layer.cornerRadius = 16
@@ -112,8 +123,9 @@ class ForeignLanguageInputBottomSheet: UIViewController {
     private var keyboardBackgroundHeightConstraint: NSLayoutConstraint?
     
     
-    init(viewModel: ForeignLanguageInputBottomSheetViewModel) {
+    init(viewModel: ForeignLanguageInputBottomSheetViewModel, type: SheetType) {
         self.viewModel = viewModel
+        self.sheetType = type
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -123,6 +135,8 @@ class ForeignLanguageInputBottomSheet: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        nextButton.setTitle(sheetType.buttonTitle, for: .normal)
         
         setupUI()
         bindViewModel()
@@ -270,8 +284,8 @@ class ForeignLanguageInputBottomSheet: UIViewController {
             left: containerView.leftAnchor,
             right: containerView.rightAnchor,
             paddingTop: 50,
-            paddingLeft: 24,
-            paddingRight: 24
+            paddingLeft: 20,
+            paddingRight: 20
         )
         
         textFieldContainer.anchor(
@@ -279,8 +293,8 @@ class ForeignLanguageInputBottomSheet: UIViewController {
             left: containerView.leftAnchor,
             right: containerView.rightAnchor,
             paddingTop: 24,
-            paddingLeft: 24,
-            paddingRight: 24,
+            paddingLeft: 20,
+            paddingRight: 20,
             height: 50
         )
         
@@ -308,9 +322,8 @@ class ForeignLanguageInputBottomSheet: UIViewController {
         
         warningLabel.anchor(
             top: textFieldContainer.bottomAnchor,
-            left: view.leftAnchor,
-            paddingTop: 8,
-            paddingLeft: 20
+            left: textFieldContainer.leftAnchor,
+            paddingTop: 8
         )
         
         nextButtonBottomConstraint = nextButton.bottomAnchor.constraint(equalTo: containerView.safeAreaLayoutGuide.bottomAnchor,
@@ -323,8 +336,8 @@ class ForeignLanguageInputBottomSheet: UIViewController {
         nextButton.anchor(
             left: containerView.leftAnchor,
             right: containerView.rightAnchor,
-            paddingLeft: 24,
-            paddingRight: 24,
+            paddingLeft: 20,
+            paddingRight: 20,
             height: 56
         )
     }

--- a/HaruUp/Presentation/Curation/InterestDetailSelect/ForeignLanguageInputBottomSheet.swift
+++ b/HaruUp/Presentation/Curation/InterestDetailSelect/ForeignLanguageInputBottomSheet.swift
@@ -54,6 +54,7 @@ class ForeignLanguageInputBottomSheet: UIViewController {
     private let textField: UITextField = {
         let tf = UITextField()
         tf.placeholder = "프랑스어"
+        tf.setPlaceholder(color: .neutral300)
         tf.borderStyle = .none
         tf.font = UIFont.pretendard(size: 16, weight: .medium)
         tf.textColor = .black
@@ -95,11 +96,14 @@ class ForeignLanguageInputBottomSheet: UIViewController {
     }()
     
     private let nextButton: UIButton = {
-        let button = UIButton()
-        button.setImage(UIImage(named: "next_btn_gray.png"), for: .normal)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.contentMode = .scaleAspectFit
-        return button
+        let btn = UIButton()
+        btn.setTitle("다음", for: .normal)
+        btn.titleLabel?.font = Typography.subtitle2.font
+        btn.backgroundColor = .neutral200
+        btn.layer.cornerRadius = 16
+        btn.clipsToBounds = true
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        return btn
     }()
     
     private let maxHeight: CGFloat = 300
@@ -392,8 +396,8 @@ class ForeignLanguageInputBottomSheet: UIViewController {
         // 5. 실시간 글자 수 체크 (2~10자)
         output.isLengthValid
             .drive(onNext: { [weak self] isValid in
-                let imageName = isValid ? "next_btn_blue" : "next_btn_gray"
-                self?.nextButton.setImage(UIImage(named: imageName), for: .normal)
+                self?.nextButton.backgroundColor = isValid ? .cta : .neutral200
+                self?.nextButton.isEnabled = isValid
             })
             .disposed(by: disposeBag)
         
@@ -420,22 +424,22 @@ class ForeignLanguageInputBottomSheet: UIViewController {
                     }
                     
                 case .empty:
-                    self.nextButton.setImage(UIImage(named: "next_btn_gray"), for: .normal)
+                    self.nextButton.backgroundColor = .neutral200
                     
                 case .tooShort, .tooLong:
                     self.warningLabel.setStyle(Typography.body4, text: "*2~15자로 입력해주세요.")
                     self.warningLabel.isHidden = false
-                    self.nextButton.setImage(UIImage(named: "next_btn_gray"), for: .normal)
+                    self.nextButton.backgroundColor = .neutral200
                     
                 case .invalidCharacters:
                     self.warningLabel.setStyle(Typography.body4, text: "*한글만 입력해주세요.")
                     self.warningLabel.isHidden = false
-                    self.nextButton.setImage(UIImage(named: "next_btn_gray"), for: .normal)
+                    self.nextButton.backgroundColor = .neutral200
                     
                 case .incompleteKorean:
                     self.warningLabel.setStyle(Typography.body4, text: "*올바른 형태로 입력해주세요.")
                     self.warningLabel.isHidden = false
-                    self.nextButton.setImage(UIImage(named: "next_btn_gray"), for: .normal)
+                    self.nextButton.backgroundColor = .neutral200
                 }
             })
             .disposed(by: disposeBag)

--- a/HaruUp/Presentation/Curation/InterestDetailSelect/InterestDetailSelectCoordinator.swift
+++ b/HaruUp/Presentation/Curation/InterestDetailSelect/InterestDetailSelectCoordinator.swift
@@ -42,7 +42,12 @@ final class InterestDetailSelectCoordinator: Coordinator {
     func showForeignLanguageInput() {
         print("🔵 외국어 입력 모달 표시")
         
-        let bottomSheet = ForeignLanguageInputBottomSheet(viewModel: ForeignLanguageInputBottomSheetViewModel())
+        let vm = ForeignLanguageInputBottomSheetViewModel()
+        
+        let bottomSheet = ForeignLanguageInputBottomSheet(
+            viewModel: vm,
+            type: .curation
+        )
         bottomSheet.modalPresentationStyle = .overFullScreen
         bottomSheet.modalTransitionStyle = .crossDissolve
         

--- a/HaruUp/Presentation/MyPage/InterestEdit/GoalInputBottomSheet.swift
+++ b/HaruUp/Presentation/MyPage/InterestEdit/GoalInputBottomSheet.swift
@@ -58,9 +58,10 @@ final class GoalInputBottomSheet: UIViewController {
     
     private let textField: UITextField = {
         let tf = UITextField()
-        tf.placeholder = "2~20자로 입력해주세요."
         tf.borderStyle = .none
         tf.textColor = .black
+        tf.placeholder = "2~20자로 입력해 주세요."
+        tf.setPlaceholder(color: .neutral300)
         tf.font = UIFont.pretendard(size: 16, weight: .medium)
         tf.translatesAutoresizingMaskIntoConstraints = false
         return tf
@@ -103,10 +104,14 @@ final class GoalInputBottomSheet: UIViewController {
     }()
     
     private let nextButton: UIButton = {
-        let button = UIButton()
-        button.setImage(UIImage(named: "next_btn_gray.png"), for: .normal)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
+        let btn = UIButton()
+        btn.setTitle("완료", for: .normal)
+        btn.titleLabel?.font = Typography.subtitle2.font
+        btn.backgroundColor = .neutral200
+        btn.layer.cornerRadius = 16
+        btn.clipsToBounds = true
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        return btn
     }()
     
     private var inputBottomSheetBottomConstraint: NSLayoutConstraint?
@@ -262,8 +267,8 @@ final class GoalInputBottomSheet: UIViewController {
             .map { $0.trimmingCharacters(in: .whitespaces).count }
             .map { $0 >= 2 && $0 <= 20 }
             .drive(onNext: { [weak self] isValid in
-                let img = isValid ? "next_btn_blue" : "next_btn_gray"
-                self?.nextButton.setImage(UIImage(named: img), for: .normal)
+                self?.nextButton.backgroundColor = isValid ? .cta : .neutral200
+                self?.nextButton.isEnabled = isValid
                 
                 // 유효한 길이면 경고 숨김
                 if isValid {
@@ -301,7 +306,7 @@ final class GoalInputBottomSheet: UIViewController {
                 if trimmed.count < 2 {
                     self.warningLabel.setStyle(Typography.body4, text: "*2자 이상으로 입력해주세요.")
                     self.warningLabel.isHidden = false
-                    self.nextButton.setImage(UIImage(named: "next_btn_gray"), for: .normal)
+                    self.nextButton.backgroundColor = .neutral200
                     return
                 }
                 
@@ -321,7 +326,7 @@ final class GoalInputBottomSheet: UIViewController {
             .bind(with: self) { owner, msg in
                 owner.warningLabel.setStyle(Typography.body4, text: msg)
                 owner.warningLabel.isHidden = false
-                owner.nextButton.setImage(UIImage(named: "next_btn_gray"), for: .normal)
+                owner.nextButton.backgroundColor = .neutral200
             }
             .disposed(by: disposeBag)
     }

--- a/HaruUp/Presentation/MyPage/InterestEdit/GoalInputBottomSheet.swift
+++ b/HaruUp/Presentation/MyPage/InterestEdit/GoalInputBottomSheet.swift
@@ -16,6 +16,9 @@ final class GoalInputBottomSheet: UIViewController {
     // ViewModel로 입력값 전달
     var onNextTapped: ((String) -> Void)?
     
+    // 초기 텍스트를 받을 변수
+    var initialText: String?
+    
     // 외부(ViewModel)에서 제어할 Subjects
     let validationSuccess = PublishRelay<Void>()
     let validationFailed = PublishRelay<String>()
@@ -117,6 +120,10 @@ final class GoalInputBottomSheet: UIViewController {
         setupKeyboardObservers()
         setupTapGestures()
         bind()
+        
+        if let text = initialText, !text.isEmpty {
+            textField.text = text
+        }
         
         // 20자 제한을 위한 델리게이트 설정
         textField.delegate = self

--- a/HaruUp/Presentation/MyPage/InterestEdit/GoalInputBottomSheet.swift
+++ b/HaruUp/Presentation/MyPage/InterestEdit/GoalInputBottomSheet.swift
@@ -67,7 +67,7 @@ final class GoalInputBottomSheet: UIViewController {
         return tf
     }()
     
-    // ✅ [추가] 클리어 버튼
+    // 클리어 버튼
     private let clearButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(named: "icon_x.png"), for: .normal)
@@ -83,7 +83,7 @@ final class GoalInputBottomSheet: UIViewController {
         return view
     }()
     
-    // ✅ [추가] 글자 수 카운트 라벨
+    // 글자 수 카운트 라벨
     private let textCountLabel: UILabel = {
         let label = UILabel()
         label.setStyle(Typography.caption3, text: "0/20")
@@ -170,11 +170,11 @@ final class GoalInputBottomSheet: UIViewController {
             containerView.heightAnchor.constraint(equalToConstant: 330), // 높이 약간 증가
             
             titleLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 40),
-            titleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 24),
+            titleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 20),
             
             textFieldContainer.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
-            textFieldContainer.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 24),
-            textFieldContainer.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -24),
+            textFieldContainer.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 20),
+            textFieldContainer.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -20),
             textFieldContainer.heightAnchor.constraint(equalToConstant: 50),
             
             // 텍스트필드 배치 (오른쪽에 클리어버튼 자리 확보)
@@ -200,12 +200,12 @@ final class GoalInputBottomSheet: UIViewController {
             
             // 경고 메시지 (왼쪽 아래)
             warningLabel.topAnchor.constraint(equalTo: textFieldContainer.bottomAnchor, constant: 8),
-            warningLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 24),
+            warningLabel.leadingAnchor.constraint(equalTo: textFieldContainer.leadingAnchor),
             warningLabel.trailingAnchor.constraint(lessThanOrEqualTo: textCountLabel.leadingAnchor, constant: -10),
             
             nextButton.bottomAnchor.constraint(equalTo: containerView.safeAreaLayoutGuide.bottomAnchor, constant: -10),
-            nextButton.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 24),
-            nextButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -24),
+            nextButton.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 20),
+            nextButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -20),
             nextButton.heightAnchor.constraint(equalToConstant: 56)
         ])
         

--- a/HaruUp/Presentation/MyPage/InterestEdit/InterestEditViewController.swift
+++ b/HaruUp/Presentation/MyPage/InterestEdit/InterestEditViewController.swift
@@ -729,7 +729,10 @@ final class InterestEditViewController: UIViewController {
     
     private func showForeignLanguageInputBottomSheet() {
         let bottomSheetViewModel = ForeignLanguageInputBottomSheetViewModel()
-        let bottomSheetVC = ForeignLanguageInputBottomSheet(viewModel: bottomSheetViewModel)
+        let bottomSheetVC = ForeignLanguageInputBottomSheet(
+            viewModel: bottomSheetViewModel,
+            type: .edit
+        )
         
         bottomSheetVC.modalPresentationStyle = .overFullScreen
         bottomSheetVC.modalTransitionStyle = .crossDissolve

--- a/HaruUp/Presentation/MyPage/InterestEdit/InterestEditViewController.swift
+++ b/HaruUp/Presentation/MyPage/InterestEdit/InterestEditViewController.swift
@@ -578,8 +578,8 @@ final class InterestEditViewController: UIViewController {
             .disposed(by: disposeBag)
         
         output.showGoalInputBottomSheet
-            .emit(with: self) { owner, _ in
-                owner.showGoalInputSheet()
+            .emit(with: self) { owner, text in
+                owner.showGoalInputSheet(initialText: text)
             }
             .disposed(by: disposeBag)
         
@@ -746,9 +746,11 @@ final class InterestEditViewController: UIViewController {
         self.present(bottomSheetVC, animated: true)
     }
     
-    private func showGoalInputSheet() {
+    private func showGoalInputSheet(initialText: String? = nil) {
         let vc = GoalInputBottomSheet()
         vc.modalPresentationStyle = .overFullScreen
+        
+        vc.initialText = initialText
         
         // 입력 완료 시 VM으로 전달
         vc.onNextTapped = { [weak self] text in

--- a/HaruUp/Presentation/MyPage/InterestEdit/InterestEditViewModel.swift
+++ b/HaruUp/Presentation/MyPage/InterestEdit/InterestEditViewModel.swift
@@ -43,7 +43,7 @@ final class InterestEditViewModel {
         let showLanguageInputBottomSheet: Signal<Void>
         
         // Goal 관련 Output
-        let showGoalInputBottomSheet: Signal<Void>      // 목표 입력 바텀시트 열기
+        let showGoalInputBottomSheet: Signal<String?>      // 목표 입력 바텀시트 열기
         let goalValidationSuccess: Signal<Void>         // 유효성 검사 성공 (바텀시트 닫기용)
         let goalValidationFailed: Signal<String>        // 유효성 검사 실패 (에러 메시지 표시용)
         let showLockAlert: Signal<Void>                 // 3회 실패 팝업
@@ -108,7 +108,7 @@ final class InterestEditViewModel {
         let showBottomSheetRelay = PublishRelay<Void>()
         let errorMessageRelay = PublishRelay<String>()
         
-        let showGoalBottomSheetRelay = PublishRelay<Void>()
+        let showGoalBottomSheetRelay = PublishRelay<String?>()
         let validationSuccessRelay = PublishRelay<Void>()
         let validationFailedRelay = PublishRelay<String>()
         let showLockAlertRelay = PublishRelay<Void>()
@@ -214,8 +214,7 @@ final class InterestEditViewModel {
                         return
                     }
                     // 바텀시트 열기 전 기존 커스텀 값 초기화 (재입력 유도)
-                    self.customGoalNameRelay.accept(nil)
-                    showGoalBottomSheetRelay.accept(())
+                    showGoalBottomSheetRelay.accept(self.customGoalNameRelay.value)
                 } else {
                     // 일반 항목 선택 시 커스텀 값 제거
                     self.customGoalNameRelay.accept(nil)
@@ -256,12 +255,12 @@ final class InterestEditViewModel {
                 guard let self = self else { return }
                 
                 if isValid {
-                    // ✅ 성공
+                    // 성공
                     self.invalidGoalAttemptCount = 0
                     self.customGoalNameRelay.accept(text)
                     validationSuccessRelay.accept(())
                 } else {
-                    // ❌ 실패 (진짜 실패인 경우만 여기로 옴)
+                    // 실패 (진짜 실패인 경우만 여기로 옴)
                     self.invalidGoalAttemptCount += 1
                     
                     if self.invalidGoalAttemptCount >= 3 {
@@ -356,12 +355,12 @@ final class InterestEditViewModel {
                 self.isLoadingRelay.accept(false) // 로딩 종료
                 
                 if success {
-                    // ✅ API가 성공(true)했을 때만 로컬 데이터 업데이트
+                    // API가 성공(true)했을 때만 로컬 데이터 업데이트
                     print("💾 API 성공: 로컬 데이터 업데이트 실행")
                     self.updateLocalData()
                     updateSuccessRelay.accept(())
                 } else {
-                    // ❌ API 실패(false) 시 에러 메시지
+                    // API 실패(false) 시 에러 메시지
                     print("💾 API 실패: 로컬 데이터 업데이트 안함")
                     errorMessageRelay.accept("관심사 수정에 실패했어요. 다시 시도해주세요.")
                 }

--- a/HaruUp/Presentation/MyPage/MyPageViewController.swift
+++ b/HaruUp/Presentation/MyPage/MyPageViewController.swift
@@ -23,6 +23,19 @@ class MyPageViewController: UIViewController {
     var onWithdraw: (() -> Void)?
     
     // MARK: - UI Components
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsVerticalScrollIndicator = false // 스크롤 바 숨김 (선택사항)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+    
+    private let contentView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.setStyle(Typography.title3, text: "마이페이지")
@@ -130,6 +143,14 @@ class MyPageViewController: UIViewController {
     
     required init?(coder: NSCoder) { fatalError() }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        // 화면이 나타날 때 네비게이션 바를 숨깁니다.
+        // 이렇게 해야 Safe Area가 화면 최상단(Status Bar 바로 아래)부터 시작됩니다.
+        navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
@@ -138,9 +159,12 @@ class MyPageViewController: UIViewController {
     
     private func setupUI() {
         view.backgroundColor = .neutral10
+
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
         
         [titleLabel, profileImageView, nicknameLabel, editProfileButton, jobLabel, goalCardView, menuStackView, versionLabel].forEach {
-            view.addSubview($0)
+            contentView.addSubview($0)
         }
         
         [goalBadgeContainer, goalNameLabel, interestTag, detailTag].forEach {
@@ -157,11 +181,22 @@ class MyPageViewController: UIViewController {
     
     private func setupConstraints() {
         NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+                        scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                        scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                        scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            
+            contentView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+                        contentView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+                        contentView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+                        contentView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            contentView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+            
+            titleLabel.topAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.topAnchor, constant: 10),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
             
             profileImageView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 30),
-            profileImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            profileImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
             profileImageView.widthAnchor.constraint(equalToConstant: 80),
             profileImageView.heightAnchor.constraint(equalToConstant: 80),
             
@@ -170,7 +205,7 @@ class MyPageViewController: UIViewController {
             nicknameLabel.trailingAnchor.constraint(lessThanOrEqualTo: editProfileButton.leadingAnchor, constant: -8),
             
             editProfileButton.topAnchor.constraint(equalTo: nicknameLabel.topAnchor, constant: 10),
-            editProfileButton.rightAnchor.constraint(equalTo: view.rightAnchor, constant: -20),
+            editProfileButton.rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: -20),
             editProfileButton.widthAnchor.constraint(equalToConstant: 36),
             editProfileButton.heightAnchor.constraint(equalToConstant: 36),
             
@@ -178,8 +213,8 @@ class MyPageViewController: UIViewController {
             jobLabel.leadingAnchor.constraint(equalTo: nicknameLabel.leadingAnchor),
             
             goalCardView.topAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: 36),
-            goalCardView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            goalCardView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            goalCardView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            goalCardView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
             //            goalCardView.heightAnchor.constraint(equalToConstant: 130),
             
             goalBadgeContainer.topAnchor.constraint(equalTo: goalCardView.topAnchor, constant: 15),
@@ -202,11 +237,12 @@ class MyPageViewController: UIViewController {
             detailTag.leadingAnchor.constraint(equalTo: interestTag.trailingAnchor, constant: 8),
             
             menuStackView.topAnchor.constraint(equalTo: goalCardView.bottomAnchor, constant: 24),
-            menuStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            menuStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            menuStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            menuStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
             
             versionLabel.topAnchor.constraint(equalTo: menuStackView.bottomAnchor, constant: 10),
-            versionLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40)
+            versionLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 40),
+            versionLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -40)
         ])
     }
     

--- a/HaruUp/Presentation/MyPage/MyPageViewModel.swift
+++ b/HaruUp/Presentation/MyPage/MyPageViewModel.swift
@@ -57,26 +57,16 @@ final class MyPageViewModel {
     }
     
     func transform(input: Input) -> Output {
-        //        let curationDataDriver = input.viewDidLoad
-        //            .map { [weak self] _ in
-        //                // 앱을 껐다 켜도 여기서 다시 불러오기 때문에 데이터가 보입니다.
-        //                return self?.tokenStorage.getCurationData() ?? CurationData()
-        //            }
-        //            .asDriver(onErrorJustReturn: CurationData())
-        
-        //        let loadData = Observable.merge(input.viewDidLoad, input.viewWillAppear)
-        //
-        //        let curationDataDriver = loadData
-        //            .map { [weak self] _ in
-        //                // TokenStorageService에서 최신 데이터를 가져옴 (수정된 닉네임이 저장되어 있어야 함)
-        //                return self?.tokenStorage.getCurationData() ?? CurationData()
-        //            }
-        //            .asDriver(onErrorJustReturn: CurationData())
-        
         // 1. 화면 진입 시 서버 데이터 요청 (viewDidLoad, viewWillAppear 둘 다)
         Observable.merge(input.viewDidLoad, input.viewWillAppear)
             .subscribe(onNext: { [weak self] in
-                self?.fetchServerData()
+                guard let self = self else { return }
+                
+                if let localData = self.tokenStorage.getCurationData() {
+                    self.curationDataRelay.accept(localData)
+                }
+                
+                self.fetchServerData()
             })
             .disposed(by: disposeBag)
         

--- a/HaruUp/Presentation/MyPage/ProfileEdit/ProfileEditViewController.swift
+++ b/HaruUp/Presentation/MyPage/ProfileEdit/ProfileEditViewController.swift
@@ -370,9 +370,34 @@ final class ProfileEditViewController: UIViewController {
     
     private func bind() {
         // 1. Back Button Action
+        // "현재 화면의 값"과 "저장된 값"을 실시간으로 비교하여 처리
         backButton.rx.tap
             .subscribe(with: self, onNext: { owner, _ in
-                owner.showCancelAlert()
+                // 1. 현재 저장되어 있는 최신 데이터 가져오기
+                // (완료 버튼을 눌렀다면 이 데이터가 갱신되어 있을 것이고, 안 눌렀다면 예전 데이터일 것입니다)
+                let saved = TokenStorageService.shared.getCurationData()
+                
+                // 2. 현재 화면에 입력/선택된 값 가져오기
+                let currentNickname = owner.nicknameTextField.text?.trimmingCharacters(in: .whitespaces) ?? ""
+                let currentJobId = owner.viewModel.selectedJobRelay.value?.id
+                let currentDetailId = owner.viewModel.selectedDetailJobRelay.value?.id
+                
+                // 3. 비교하기 (저장된 값 vs 현재 값)
+                // 닉네임이 다른가? (저장된 닉네임이 없으면 빈 문자열과 비교)
+                let isNicknameChanged = currentNickname != (saved?.nickname ?? "")
+                
+                // 직업이 다른가?
+                let isJobChanged = currentJobId != saved?.job?.id
+                
+                // 세부 직무가 다른가?
+                let isDetailChanged = currentDetailId != saved?.jobDetail?.id
+                
+                // 4. 하나라도 다르면(수정 중이면) Alert, 아니면 바로 Pop
+                if isNicknameChanged || isJobChanged || isDetailChanged {
+                    owner.showCancelAlert()
+                } else {
+                    owner.navigationController?.popViewController(animated: true)
+                }
             })
             .disposed(by: disposeBag)
         

--- a/HaruUp/Presentation/MyPage/ProfileEdit/ProfileEditViewController.swift
+++ b/HaruUp/Presentation/MyPage/ProfileEdit/ProfileEditViewController.swift
@@ -637,10 +637,10 @@ final class ProfileEditViewController: UIViewController {
                 }
                 
                 owner.showToast(message: message)
-                
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
-                    owner.navigationController?.popViewController(animated: true)
-                }
+//                아래의 화면 이동(pop) 코드를 삭제하여 화면에 머물게 함
+//                DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+//                    owner.navigationController?.popViewController(animated: true)
+//                }
             })
             .disposed(by: disposeBag)
     }
@@ -779,7 +779,19 @@ final class ProfileEditViewController: UIViewController {
         ])
         
         toastContainer.alpha = 0
-        UIView.animate(withDuration: 0.3) { toastContainer.alpha = 1 }
+        //        UIView.animate(withDuration: 0.3) { toastContainer.alpha = 1 }
+        // 1. 페이드 인 (0.3초)
+        UIView.animate(withDuration: 0.3, animations: {
+            toastContainer.alpha = 1
+        }) { _ in
+            // 2. 2초 대기 후 페이드 아웃
+            UIView.animate(withDuration: 0.3, delay: 2.0, options: .curveEaseOut, animations: {
+                toastContainer.alpha = 0
+            }) { _ in
+                // 3. 뷰 계층에서 제거
+                toastContainer.removeFromSuperview()
+            }
+        }
     }
 }
 
@@ -811,14 +823,6 @@ extension ProfileEditViewController: UIGestureRecognizerDelegate {
             self.view.layoutIfNeeded()
         }
     }
-    
-    //    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-    //        if touch.view is UIButton {
-    //            return false
-    //        }
-    //
-    //        return true
-    //    }
     
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         // 버튼이나 테이블뷰 셀 터치 시 제스처 무시 (드롭다운 터치 문제 방지)

--- a/HaruUp/Presentation/MyPage/ProfileEdit/ProfileEditViewController.swift
+++ b/HaruUp/Presentation/MyPage/ProfileEdit/ProfileEditViewController.swift
@@ -165,6 +165,16 @@ final class ProfileEditViewController: UIViewController {
         return btn
     }()
     
+    private let detailJobWarningLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .secondaryRed200
+        label.textAlignment = .left
+        label.font = Typography.body4.font // 또는 원하시는 폰트
+        label.isHidden = true // 기본적으로 숨김
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
     private let completeButton: UIButton = {
         let btn = UIButton()
         btn.setTitle("완료", for: .normal)
@@ -254,7 +264,9 @@ final class ProfileEditViewController: UIViewController {
         
         [customNavBar, nicknameTitleLabel, textFieldContainer, warningLabel,
          jobTitleLabel, jobSelectButton,
-         detailJobTitleLabel, detailJobSelectButton, buttonBackgroundView,
+         detailJobTitleLabel, detailJobSelectButton,
+         detailJobWarningLabel,
+         buttonBackgroundView,
          completeButton].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             view.addSubview($0)
@@ -349,6 +361,10 @@ final class ProfileEditViewController: UIViewController {
             detailJobSelectButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             detailJobSelectButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             detailJobSelectButton.heightAnchor.constraint(equalToConstant: 55),
+            
+            detailJobWarningLabel.topAnchor.constraint(equalTo: detailJobSelectButton.bottomAnchor, constant: 6),
+            detailJobWarningLabel.leadingAnchor.constraint(equalTo: detailJobSelectButton.leadingAnchor),
+            detailJobWarningLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             
             // Dropdowns (Button 바로 아래 위치)
             jobDropdown.topAnchor.constraint(equalTo: jobSelectButton.bottomAnchor, constant: 4),
@@ -666,6 +682,26 @@ final class ProfileEditViewController: UIViewController {
 //                DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
 //                    owner.navigationController?.popViewController(animated: true)
 //                }
+            })
+            .disposed(by: disposeBag)
+        
+        // 5. 직업 선택 경고 메시지 바인딩
+        output.jobWarning
+            .drive(with: self, onNext: { owner, warningMessage in
+                if let message = warningMessage {
+                    // 경고 메시지가 있으면(직업은 골랐는데 세부직무가 없으면) 텍스트 설정 및 보이기
+                    owner.detailJobWarningLabel.text = message
+                    owner.detailJobWarningLabel.isHidden = false
+                    owner.detailJobWarningLabel.font = Typography.body4.font
+                    
+                    // (선택사항) 경고가 떴을 때 버튼 테두리를 빨간색으로 바꾸고 싶다면:
+                    // owner.detailJobSelectButton.layer.borderColor = UIColor.secondaryRed200.cgColor
+                } else {
+                    // nil이면(정상 상태면) 숨기기
+                    owner.detailJobWarningLabel.isHidden = true
+                    
+                    // (선택사항) 테두리 색상 원복 (활성화/비활성화 로직이 따로 있어서 생략 가능)
+                }
             })
             .disposed(by: disposeBag)
     }

--- a/HaruUp/Presentation/MyPage/ProfileEdit/ProfileEditViewController.swift
+++ b/HaruUp/Presentation/MyPage/ProfileEdit/ProfileEditViewController.swift
@@ -542,21 +542,41 @@ final class ProfileEditViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-        // 4. 세부 직무 선택 상태 업데이트 (버튼 타이틀만 업데이트)
+        // 4. 세부 직무 선택 상태 업데이트 (버튼 타이틀 변경 로직)
         output.currentDetailJobName
             .drive(with: self, onNext: { owner, name in
-                let title = name ?? "세부 직무 선택"
-                let color: UIColor = name != nil ? .cta : .neutral800
                 
+                var titleText = ""
+                var titleColor: UIColor = .neutral800
+                
+                // 1. 세부 직무가 선택되어 있는지 확인
+                if let selectedName = name {
+                    // [선택됨] -> 해당 직무 이름 표시 & 색상 강조
+                    titleText = selectedName
+                    titleColor = .cta
+                } else {
+                    // [선택 안 됨] -> Placeholder 표시 (직업에 따라 문구 분기)
+                    // 현재 선택된 직업이 무엇인지 확인
+                    let currentJobName = owner.viewModel.selectedJobRelay.value?.jobName
+                    
+                    if ["학생", "취준생"].contains(currentJobName) {
+                        titleText = "하고 싶은 세부 직무 선택"
+                    } else {
+                        titleText = "세부 직무 선택"
+                    }
+                    titleColor = .neutral800
+                }
+                
+                // 2. 버튼 UI 업데이트
                 owner.detailJobSelectButton.setAttributedTitle(
                     NSAttributedString(
-                        string: title,
-                        attributes: [.font: Typography.body1.font, .foregroundColor: color]
+                        string: titleText,
+                        attributes: [.font: Typography.body1.font, .foregroundColor: titleColor]
                     ),
                     for: .normal
                 )
                 
-                // 선택 완료 시 드롭다운 닫기 + UI 원래 상태로 복귀
+                // 3. 선택 완료 시 드롭다운 닫기 + 화살표 원복 (기존 로직 유지)
                 if name != nil {
                     owner.detailJobDropdown.isHidden = true
                     owner.updateDropdownState(

--- a/HaruUp/Presentation/MyPage/ProfileEdit/ProfileEditViewModel.swift
+++ b/HaruUp/Presentation/MyPage/ProfileEdit/ProfileEditViewModel.swift
@@ -38,6 +38,8 @@ final class ProfileEditViewModel {
         let selectedJobId: Driver<Int?>                     // 드롭다운 하이라이트용
         let selectedDetailJobId: Driver<Int?>               // 드롭다운 하이라이트용
         let isDetailJobEnabled: Driver<Bool>
+        
+        let jobWarning: Driver<String?>                     // 직업 선택 관련 경고 메시지
     }
     
     private let disposeBag = DisposeBag()
@@ -53,6 +55,8 @@ final class ProfileEditViewModel {
     let selectedDetailJobRelay = BehaviorRelay<JobDetail?>(value: TokenStorageService.shared.getCurationData()?.jobDetail)
     private let jobListRelay = BehaviorRelay<[Job]>(value: [])
     private let detailJobListRelay = BehaviorRelay<[JobDetail]>(value: [])
+    
+    private let jobWarningRelay = PublishRelay<String?>()
     
     // 외부 의존성
     private let nicknameServiceVM: NicknameSelectViewModel
@@ -95,19 +99,10 @@ final class ProfileEditViewModel {
                 
                 let trimmed = nickname.trimmingCharacters(in: .whitespaces)
                 
-                // 닉네임이 비어있으면 무조건 비활성화
-                if trimmed.isEmpty { return false }
-                
-                // 닉네임 변경 여부
                 let nicknameChanged = trimmed != self.initialNicknameValue
-                
-                // 직업 변경 여부
                 let jobChanged = job?.id != self.savedData?.job?.id
-                
-                // 세부직업 변경 여부
                 let jobDetailChanged = jobDetail?.id != self.savedData?.jobDetail?.id
                 
-                // 하나라도 변경되었으면 활성화
                 return nicknameChanged || jobChanged || jobDetailChanged
             }
             .asDriver(onErrorJustReturn: false)
@@ -149,67 +144,94 @@ final class ProfileEditViewModel {
         input.detailJobSelected
             .map { $0 as? JobDetail }
             .compactMap { $0 }
+            .do(onNext: { [weak self] _ in
+                self?.jobWarningRelay.accept(nil) // 경고 숨김
+            })
             .bind(to: selectedDetailJobRelay)
             .disposed(by: disposeBag)
         
         // 완료 버튼 탭 로직
-        input.completeButtonTapped
-            .withLatestFrom(Observable.combineLatest(
-                nicknameRelay,
-                selectedJobRelay,
-                selectedDetailJobRelay
-            ))
-            .flatMapLatest { [weak self] (nickname, job, jobDetail) -> Observable<NicknameValidationResult> in
-                guard let self = self else { return .just(.empty) }
-                
-                // 닉네임 변경 여부 확인
-                let nicknameChanged = nickname.trimmingCharacters(in: .whitespaces) != self.initialNicknameValue
-                
-                // 닉네임이 변경되지 않았으면 중복 체크 건너뛰기
-                if !nicknameChanged {
-                    return .just(.success)
-                }
-                
-                // [Step 1] 기본 유효성 검사 (길이, 한글 등)
-                let basicValidation = self.validateNickname(nickname)
-                guard case .success = basicValidation else {
-                    return .just(basicValidation) // 실패 시 즉시 반환
-                }
-                
-                // [Step 2] 닉네임 중복 체크 API 호출 (기존 VM 활용)
-                return self.nicknameServiceVM.checkNicknameDuplicate(nickname)
-            }
-            .flatMapLatest { [weak self] result -> Observable<Bool> in
-                guard let self = self else { return .just(false) }
-                
-                // 결과 UI에 전달 (경고 메시지 표시 등)
-                validationResultRelay.accept(result)
-                
-                if result == .success {
-                    // [Step 3] 중복 체크 통과 시 -> 프로필 수정 API 호출
-                    return self.requestUpdateProfile(
-                        nickname: self.nicknameRelay.value,
-                        jobId: self.selectedJobRelay.value?.id,
-                        jobDetailId: self.selectedDetailJobRelay.value?.id
-                    )
-                } else {
-                    // 중복이거나 기타 오류면 중단
-                    return .just(false)
-                }
-            }
-            .subscribe(onNext: { [weak self] success in
-                if success {
-                    if let self = self {
-                        var currentData = TokenStorageService.shared.getCurationData() ?? CurationData()
-                        currentData.nickname = self.nicknameRelay.value
-                        currentData.job = self.selectedJobRelay.value
-                        currentData.jobDetail = self.selectedDetailJobRelay.value
-                        TokenStorageService.shared.saveCurationData(currentData)
+                // 순서: 1. 직무 검사 -> 2. 닉네임 검사 -> 3. API 호출
+                input.completeButtonTapped
+                    .withLatestFrom(Observable.combineLatest(
+                        nicknameRelay,
+                        selectedJobRelay,
+                        selectedDetailJobRelay
+                    ))
+                    .flatMapLatest { [weak self] (nickname, job, jobDetail) -> Observable<Bool> in
+                        guard let self = self else { return .just(false) }
+                        
+                        // 1. 직업 유효성 검사
+                        if let currentJob = job {
+                            let requiredJobs = ["학생", "직장인", "취준생"]
+                            // 해당 직업군인데 세부 직무가 없으면?
+                            if requiredJobs.contains(currentJob.jobName) && jobDetail == nil {
+                                // 경고 메시지 띄우고
+                                self.jobWarningRelay.accept("*하고 싶은 세부 직무를 선택해주세요.")
+                                // 여기서 흐름 종료 (API 호출 안 함)
+                                return .just(false)
+                            }
+                        }
+                        
+                        // 통과했다면 경고 메시지 지움
+                        self.jobWarningRelay.accept(nil)
+                        
+                        // 2.닉네임 변경 여부 확인 (기존 로직 유지)
+                        
+                        let nicknameChanged = nickname.trimmingCharacters(in: .whitespaces) != self.initialNicknameValue
+                        
+                        // 닉네임이 안 바뀌었으면? -> 중복 체크 없이 바로 저장 API 호출
+                        // (직업만 바꿨을 수도 있으니까요)
+                        if !nicknameChanged {
+                            return self.requestUpdateProfile(
+                                nickname: nickname,
+                                jobId: job?.id,
+                                jobDetailId: jobDetail?.id
+                            )
+                        }
+                        
+                        // 3. 닉네임 기본 유효성 검사 (기존 로직 유지)
+                        let basicValidation = self.validateNickname(nickname)
+                        
+                        // 검사 실패 시
+                        guard case .success = basicValidation else {
+                            validationResultRelay.accept(basicValidation) // 에러 메시지 띄우기
+                            return .just(false) // 흐름 종료
+                        }
+                        
+                        // 4. [EXISTING] 닉네임 중복 체크 API (기존 로직 유지)
+                        return self.nicknameServiceVM.checkNicknameDuplicate(nickname)
+                            .flatMap { result -> Observable<Bool> in
+                                validationResultRelay.accept(result) // 결과 UI 전달
+                                
+                                if result == .success {
+                                    // 중복 체크 통과 -> 최종 저장 API 호출
+                                    return self.requestUpdateProfile(
+                                        nickname: nickname,
+                                        jobId: job?.id,
+                                        jobDetailId: jobDetail?.id
+                                    )
+                                } else {
+                                    // 중복됨 -> 중단
+                                    return .just(false)
+                                }
+                            }
                     }
-                    updateSuccessRelay.accept(())
-                }
-            })
-            .disposed(by: disposeBag)
+                    .subscribe(onNext: { [weak self] success in
+                        
+                        // 5.성공 후 처리
+                        if success {
+                            if let self = self {
+                                var currentData = TokenStorageService.shared.getCurationData() ?? CurationData()
+                                currentData.nickname = self.nicknameRelay.value
+                                currentData.job = self.selectedJobRelay.value
+                                currentData.jobDetail = self.selectedDetailJobRelay.value
+                                TokenStorageService.shared.saveCurationData(currentData)
+                            }
+                            updateSuccessRelay.accept(())
+                        }
+                    })
+                    .disposed(by: disposeBag)
         
         let isDetailJobEnabled = selectedJobRelay
             .map { job -> Bool in
@@ -217,6 +239,22 @@ final class ProfileEditViewModel {
                 return jobName != "자영업"  // 자영업이 아니면 활성화
             }
             .asDriver(onErrorJustReturn: false)
+        
+        // 세부 직무 미선택 경고 로직
+        // "학생", "직장인", "취준생"을 골랐는데 세부직무가 없으면 경고 메시지 리턴
+//        let jobWarning = Observable.combineLatest(selectedJobRelay, selectedDetailJobRelay)
+//            .map { job, detail -> String? in
+//                guard let currentJob = job else { return nil }
+//                
+//                let requiredJobs = ["학생", "직장인", "취준생"]
+//                if requiredJobs.contains(currentJob.jobName) && detail == nil {
+//                    return "*세부 직무를 선택해주세요."
+//                }
+//                return nil
+//            }
+//            .asDriver(onErrorJustReturn: nil)
+        
+        let jobWarning = jobWarningRelay.asDriver(onErrorJustReturn: nil)
         
         return Output(
             initialNickname: initialNicknameDriver,
@@ -231,7 +269,9 @@ final class ProfileEditViewModel {
             currentDetailJobName: selectedDetailJobRelay.map { $0?.jobDetailName }.asDriver(onErrorJustReturn: nil),
             selectedJobId: selectedJobRelay.map { $0?.id }.asDriver(onErrorJustReturn: nil),
             selectedDetailJobId: selectedDetailJobRelay.map { $0?.id }.asDriver(onErrorJustReturn: nil),
-            isDetailJobEnabled: isDetailJobEnabled
+            isDetailJobEnabled: isDetailJobEnabled,
+            
+            jobWarning: jobWarning
         )
     }
     

--- a/HaruUp/Presentation/MyPage/ProfileEdit/ProfileEditViewModel.swift
+++ b/HaruUp/Presentation/MyPage/ProfileEdit/ProfileEditViewModel.swift
@@ -167,7 +167,7 @@ final class ProfileEditViewModel {
                             // 해당 직업군인데 세부 직무가 없으면?
                             if requiredJobs.contains(currentJob.jobName) && jobDetail == nil {
                                 // 경고 메시지 띄우고
-                                self.jobWarningRelay.accept("*하고 싶은 세부 직무를 선택해주세요.")
+                                self.jobWarningRelay.accept("*세부 직무를 선택해주세요.")
                                 // 여기서 흐름 종료 (API 호출 안 함)
                                 return .just(false)
                             }


### PR DESCRIPTION
## 작업내용
- 프로필 수정 후 화면 그대로 남아있도록, 토스트 2초뒤 사라지도록 변경
- 프로필 수정 후 마이페이지에 바로 반영되도록 수정
- 마이페이지 화면 스크롤 추가
- 큐레이션의 직접 입력 버튼 겹쳐보이는 문제 수정
- 목표 & 기타외국어 직접입력 바텀 시트 텍스트 필드 수정
- 직접입력의 placeholder 색상 변경
- 버튼 이미지인것들 모두 삭제
- 기타 외국어 입력창 용도마다 다른 버튼 타이틀로 수정, CTA 버튼 여백 수정
- 프로필 수정 후 완료 버튼을 누르지 않았을 경우에만 alert창 뜨도록 변경
- 직업 수정에서 직장인, 취준생, 학생일 경우 셀렉트 버튼 타이틀 변경 & 세부 직무 선택하지 않았을 경우 경고 메세지 기능 추가
- 드롭다운 뷰 아이템 높이 및 스크롤 수정