### PR TITLE
fix: 미션 소스 구분 기반 추천/재추천 조회 로직 개선

### DIFF
--- a/HaruUp.xcodeproj/project.pbxproj
+++ b/HaruUp.xcodeproj/project.pbxproj
@@ -15,12 +15,24 @@
 		4893D23F2ED9771B0018D43A /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 4893D23E2ED9771B0018D43A /* KakaoSDKUser */; };
 		4893D2452ED985650018D43A /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 4893D2442ED985650018D43A /* RxCocoa */; };
 		4893D2472ED985650018D43A /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 4893D2462ED985650018D43A /* RxSwift */; };
+		7A00000C2F5000000010000C /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 4893D2462ED985650018D43A /* RxSwift */; };
 		CF46F20A2F2A159800CDCCDE /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = CF46F2092F2A159800CDCCDE /* FirebaseCore */; };
 		CFC7F0942F47FD0800BCF147 /* AmplitudeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CFC7F0932F47FD0800BCF147 /* AmplitudeSwift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		7A00000A2F5000000010000A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4893D1E42ED6E2AE0018D43A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4893D1EB2ED6E2AE0018D43A;
+			remoteInfo = HaruUp;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		4893D1EC2ED6E2AE0018D43A /* HaruUp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HaruUp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7A0000012F50000000100001 /* HaruUpTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HaruUpTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -40,6 +52,11 @@
 				4893D2012ED6E2AF0018D43A /* Exceptions for "HaruUp" folder in "HaruUp" target */,
 			);
 			path = HaruUp;
+			sourceTree = "<group>";
+		};
+		7A0000022F50000000100002 /* HaruUpTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = HaruUpTests;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -62,6 +79,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7A0000032F50000000100003 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7A00000C2F5000000010000C /* RxSwift in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -69,6 +94,7 @@
 			isa = PBXGroup;
 			children = (
 				4893D1EE2ED6E2AE0018D43A /* HaruUp */,
+				7A0000022F50000000100002 /* HaruUpTests */,
 				CF46F2082F2A159800CDCCDE /* Frameworks */,
 				4893D1ED2ED6E2AE0018D43A /* Products */,
 			);
@@ -78,6 +104,7 @@
 			isa = PBXGroup;
 			children = (
 				4893D1EC2ED6E2AE0018D43A /* HaruUp.app */,
+				7A0000012F50000000100001 /* HaruUpTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -124,6 +151,30 @@
 			productReference = 4893D1EC2ED6E2AE0018D43A /* HaruUp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		7A0000062F50000000100006 /* HaruUpTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7A0000072F50000000100007 /* Build configuration list for PBXNativeTarget "HaruUpTests" */;
+			buildPhases = (
+				7A0000042F50000000100004 /* Sources */,
+				7A0000032F50000000100003 /* Frameworks */,
+				7A0000052F50000000100005 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7A00000B2F5000000010000B /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				7A0000022F50000000100002 /* HaruUpTests */,
+			);
+			name = HaruUpTests;
+			packageProductDependencies = (
+				4893D2462ED985650018D43A /* RxSwift */,
+			);
+			productName = HaruUpTests;
+			productReference = 7A0000012F50000000100001 /* HaruUpTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -136,6 +187,10 @@
 				TargetAttributes = {
 					4893D1EB2ED6E2AE0018D43A = {
 						CreatedOnToolsVersion = 26.1;
+					};
+					7A0000062F50000000100006 = {
+						CreatedOnToolsVersion = 26.1;
+						TestTargetID = 4893D1EB2ED6E2AE0018D43A;
 					};
 				};
 			};
@@ -162,12 +217,20 @@
 			projectRoot = "";
 			targets = (
 				4893D1EB2ED6E2AE0018D43A /* HaruUp */,
+				7A0000062F50000000100006 /* HaruUpTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		4893D1EA2ED6E2AE0018D43A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7A0000052F50000000100005 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -184,7 +247,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7A0000042F50000000100004 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		7A00000B2F5000000010000B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4893D1EB2ED6E2AE0018D43A /* HaruUp */;
+			targetProxy = 7A00000A2F5000000010000A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		4893D2032ED6E2AF0018D43A /* Debug */ = {
@@ -376,6 +454,50 @@
 			};
 			name = Release;
 		};
+		7A0000082F50000000100008 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5G6N83PM9C;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swyp.HaruUpTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HaruUp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/HaruUp";
+			};
+			name = Debug;
+		};
+		7A0000092F50000000100009 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5G6N83PM9C;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swyp.HaruUpTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HaruUp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/HaruUp";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -393,6 +515,15 @@
 			buildConfigurations = (
 				4893D2032ED6E2AF0018D43A /* Debug */,
 				4893D2042ED6E2AF0018D43A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7A0000072F50000000100007 /* Build configuration list for PBXNativeTarget "HaruUpTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7A0000082F50000000100008 /* Debug */,
+				7A0000092F50000000100009 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/HaruUp/Data/UserDefaults/UserDefaultsKey.swift
+++ b/HaruUp/Data/UserDefaults/UserDefaultsKey.swift
@@ -10,6 +10,8 @@ enum UserDefaultsKey {
     static let todayMissionSelectedDate = "todayMissionSelectedDate"
     /// 사용자가 확인한 관심사의 ID
     static let selectedMemberInterestId = "selectedMemberInterestId"
+    /// 챗봇 목표 기반 미션 플로우 사용 여부
+    static let usesChatbotGoalMissions = "usesChatbotGoalMissions"
     /// 오늘의 미션 인트로를 마지막으로 본 날짜
     static let lastIntroShownDate = "lastIntroShownDate"
 }

--- a/HaruUp/Data/UserDefaults/UserDefaultsManager.swift
+++ b/HaruUp/Data/UserDefaults/UserDefaultsManager.swift
@@ -21,14 +21,25 @@ final class UserDefaultsManager {
         set {
             if let newValue {
                 defaults.set(newValue, forKey: UserDefaultsKey.selectedMemberInterestId)
+                usesChatbotGoalMissions = newValue == MissionSource.chatbotGoalInterestId
             } else {
                 defaults.removeObject(forKey: UserDefaultsKey.selectedMemberInterestId)
             }
+        }
+    }
+
+    var usesChatbotGoalMissions: Bool {
+        get {
+            defaults.bool(forKey: UserDefaultsKey.usesChatbotGoalMissions)
+        }
+        set {
+            defaults.set(newValue, forKey: UserDefaultsKey.usesChatbotGoalMissions)
         }
     }
     
     /// 선택된 관심사 초기화
     func clearSelectedMemberInterestId() {
         selectedMemberInterestId = nil
+        usesChatbotGoalMissions = false
     }
 }

--- a/HaruUp/Network/Service/Mission/MissionDTO.swift
+++ b/HaruUp/Network/Service/Mission/MissionDTO.swift
@@ -89,7 +89,7 @@ enum MemberMission {
     /// 미션 재 요청
     struct RetryRecommendRequestDTO: Encodable {
         let memberInterestId: Int
-        let excludeMemberMissionIds: [Int]
+        let excludeMemberMissionIds: [Int]?
     }
     
     struct RetryRecommendResponseDTO: Decodable {

--- a/HaruUp/Network/Service/Mission/MissionService.swift
+++ b/HaruUp/Network/Service/Mission/MissionService.swift
@@ -15,7 +15,7 @@ protocol MissionServiceProtocol {
     // 다양한 관심사로 미션 추천
     func requestRecommendedMultipleMissions(memberInterestIds: [Int]) -> Single<MemberMission.RecommendMultipleResponseDTO>
     // 미션 재추천
-    func retryRecommendMissions(memberInterestId: Int, excludeMissionIDs: [Int]) -> Single<MemberMission.RetryRecommendResponseDTO>
+    func retryRecommendMissions(memberInterestId: Int, excludeMissionIDs: [Int]?) -> Single<MemberMission.RetryRecommendResponseDTO>
     // 미션 선택 완료
     func selectMissions(missionIDs: [Int]) -> Single<MemberMission.SelectMissionResponseDTO>
     // 미션 목록 표시
@@ -62,7 +62,7 @@ final class MissionService: Service, MissionServiceProtocol {
         return request(url, method: .post, header: headers, body: body)
     }
     
-    func retryRecommendMissions(memberInterestId: Int, excludeMissionIDs: [Int]) -> Single<MemberMission.RetryRecommendResponseDTO> {
+    func retryRecommendMissions(memberInterestId: Int, excludeMissionIDs: [Int]?) -> Single<MemberMission.RetryRecommendResponseDTO> {
         let url: String = NetworkDefine.MissionAPI.retry.url
         
         var headers: HTTPHeaders = ["Content-Type": "application/json"]

--- a/HaruUp/Network/Service/Mission/MissionSource.swift
+++ b/HaruUp/Network/Service/Mission/MissionSource.swift
@@ -1,0 +1,47 @@
+//
+//  MissionSource.swift
+//  HaruUp
+//
+//  Created by Codex on 6/24/26.
+//
+
+import Foundation
+
+enum MissionSource: Equatable {
+    static let chatbotGoalInterestId = 0
+
+    case chatbot
+    case interest(ids: [Int])
+
+    init(memberInterestIds: [Int]) {
+        let interestIds = memberInterestIds.filter { $0 != Self.chatbotGoalInterestId }
+        self = interestIds.isEmpty ? .chatbot : .interest(ids: interestIds)
+    }
+
+    var recommendationMemberInterestIds: [Int] {
+        switch self {
+        case .chatbot:
+            return [Self.chatbotGoalInterestId]
+        case .interest(let ids):
+            return ids
+        }
+    }
+
+    var retryMemberInterestId: Int {
+        switch self {
+        case .chatbot:
+            return Self.chatbotGoalInterestId
+        case .interest(let ids):
+            return ids.first ?? Self.chatbotGoalInterestId
+        }
+    }
+
+    var shouldSendRetryExcludeMissionIds: Bool {
+        switch self {
+        case .chatbot:
+            return false
+        case .interest:
+            return true
+        }
+    }
+}

--- a/HaruUp/Network/Service/Service.swift
+++ b/HaruUp/Network/Service/Service.swift
@@ -10,6 +10,11 @@ import RxSwift
 import Alamofire
 
 class Service {
+    private struct APIErrorResponse: Decodable {
+        let errorMessage: String?
+        let message: String?
+    }
+
     /// JSON Body 요청
     func request<T: Decodable, B: Encodable>(_ url: String, method: Alamofire.HTTPMethod, header: HTTPHeaders, body: B) -> Single<T> {
         
@@ -20,7 +25,8 @@ class Service {
                     debugPrint(resp)
                     switch resp.result {
                     case .success(let value): single(.success(value))
-                    case .failure(let error): single(.failure(error))
+                    case .failure(let error):
+                        single(.failure(self.apiError(from: resp.data, statusCode: resp.response?.statusCode, fallback: error)))
                     }
                 }
             return Disposables.create { req.cancel() }
@@ -49,7 +55,7 @@ class Service {
                        let body = String(data: data, encoding: .utf8) {
                         print("Server error body:", body)
                     }
-                    single(.failure(error))
+                    single(.failure(self.apiError(from: resp.data, statusCode: resp.response?.statusCode, fallback: error)))
                 }
             }
 
@@ -66,10 +72,26 @@ class Service {
                     debugPrint(resp)
                     switch resp.result {
                     case .success(let value): single(.success(value))
-                    case .failure(let error): single(.failure(error))
+                    case .failure(let error):
+                        single(.failure(self.apiError(from: resp.data, statusCode: resp.response?.statusCode, fallback: error)))
                     }
                 }
             return Disposables.create { req.cancel() }
         }
+    }
+
+    private func apiError(from data: Data?, statusCode: Int?, fallback: Error) -> Error {
+        guard let data,
+              let response = try? JSONDecoder().decode(APIErrorResponse.self, from: data),
+              let message = response.errorMessage ?? response.message,
+              !message.isEmpty else {
+            return fallback
+        }
+
+        return NSError(
+            domain: "HaruUpAPIError",
+            code: statusCode ?? -1,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
     }
 }

--- a/HaruUp/Presentation/Base/AppCoordinator.swift
+++ b/HaruUp/Presentation/Base/AppCoordinator.swift
@@ -205,6 +205,8 @@ final class AppCoordinator: Coordinator {
             }
 
             let missions = curationData.chatbotMissions ?? []
+            UserDefaultsManager.shared.selectedMemberInterestId = nil
+            UserDefaultsManager.shared.usesChatbotGoalMissions = true
 
             self.chatbotService.chatbotSetup(characterId: characterId, nickname: nickname)
                 .observe(on: MainScheduler.instance)
@@ -230,7 +232,7 @@ final class AppCoordinator: Coordinator {
             navigationController: navigationController,
             missionService: MissionService(),
             interestsService: InterestsService.shared,
-            chatbotMissions: missions.isEmpty ? nil : missions
+            chatbotMissions: missions
         )
 
         missionCoordinator.onFinish = { [weak self, weak missionCoordinator] in

--- a/HaruUp/Presentation/Home/TodayMission/TodayMissionListViewController.swift
+++ b/HaruUp/Presentation/Home/TodayMission/TodayMissionListViewController.swift
@@ -51,6 +51,18 @@ class TodayMissionListViewController: UIViewController {
         
         return tableView
     }()
+
+    private let emptyStateLabel: UILabel = {
+        let label = UILabel()
+        label.text = "추천된 미션이 없어요.\n잠시 후 다시 시도해주세요."
+        label.textColor = .neutral600
+        label.font = .pretendard(size: 16, weight: .medium)
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.isHidden = true
+
+        return label
+    }()
     
     private let refreshButton: UIButton = {
         let button = UIButton()
@@ -176,6 +188,9 @@ class TodayMissionListViewController: UIViewController {
     private func configureTableview() {
         view.addSubview(tableView)
         tableView.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(emptyStateLabel)
+        emptyStateLabel.translatesAutoresizingMaskIntoConstraints = false
         
         tableView.delegate = self
         
@@ -184,6 +199,11 @@ class TodayMissionListViewController: UIViewController {
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: bottomViewContainer.topAnchor),
+
+            emptyStateLabel.centerXAnchor.constraint(equalTo: tableView.centerXAnchor),
+            emptyStateLabel.centerYAnchor.constraint(equalTo: tableView.centerYAnchor),
+            emptyStateLabel.leadingAnchor.constraint(greaterThanOrEqualTo: tableView.leadingAnchor, constant: 24),
+            emptyStateLabel.trailingAnchor.constraint(lessThanOrEqualTo: tableView.trailingAnchor, constant: -24),
         ])
     }
     
@@ -301,6 +321,18 @@ class TodayMissionListViewController: UIViewController {
                 }
             }
             .disposed(by: disposeBag)
+
+        let loadedMissions = output.missions
+            .skip(1)
+            .share(replay: 1)
+
+        Observable.combineLatest(loadedMissions, output.isLoading)
+            .map { missions, isLoading in
+                return isLoading || !missions.isEmpty
+            }
+            .observe(on: MainScheduler.instance)
+            .bind(to: emptyStateLabel.rx.isHidden)
+            .disposed(by: disposeBag)
         
         output.retryCount
             .observe(on: MainScheduler.instance)
@@ -327,7 +359,7 @@ class TodayMissionListViewController: UIViewController {
         output.errorMessage
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] message in
-                // TODO: 에러 토스트 등 UI 처리 추가 예정
+                self?.showErrorAlert(message: message)
             })
             .disposed(by: disposeBag)
         
@@ -380,6 +412,12 @@ class TodayMissionListViewController: UIViewController {
                 }
             })
             .disposed(by: disposeBag)
+    }
+
+    private func showErrorAlert(message: String) {
+        let alert = UIAlertController(title: "오류", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        present(alert, animated: true)
     }
     
 //    @objc private func closeButtonTapped() {

--- a/HaruUp/Presentation/Home/TodayMission/TodayMissionListViewModel.swift
+++ b/HaruUp/Presentation/Home/TodayMission/TodayMissionListViewModel.swift
@@ -73,37 +73,30 @@ final class TodayMissionListViewModel {
         let errorSubject = PublishSubject<String>()
         
         /// 서버로부터 미션 조회
-        // 화면 진입 + 새로고침을 하나의 트리거
-        let initialLoad = Observable.merge(input.viewDidLoad, input.refreshTap)
-        
-        initialLoad
+        // 챗봇 완료 직후 첫 진입은 answer 응답의 missions를 그대로 표시하고 추천 API를 중복 호출하지 않는다.
+        let injectedInitialLoad = input.viewDidLoad
+            .take(1)
+            .compactMap { [weak self] _ in self?.chatbotMissions }
+
+        // 일반 진입/재진입 및 새로고침은 현재 미션 소스에 맞춰 서버에서 재조회한다.
+        let apiInitialLoad = input.viewDidLoad
+            .take(1)
+            .filter { [weak self] _ in self?.chatbotMissions == nil }
+
+        let apiLoad = Observable.merge(apiInitialLoad, input.refreshTap)
             .flatMapLatest { [weak self] _ -> Observable<[MemberMission.MissionDTO]> in
-                guard let self = self else { return .empty() }
-
-                // 챗봇 플로우: 미션이 직접 주입된 경우 API 호출 생략
-                if let injected = self.chatbotMissions {
-                    return .just(injected)
-                }
-
+                guard let self else { return .empty() }
                 loadingSubject.onNext(true)
 
-                return self.resolveMemberInterestId()
-                    .flatMap { id -> Single<[MemberMission.MissionDTO]> in
-                        return self.missionService.requestRecommendedMissions(memberInterestId: id)
-                            .flatMap { response -> Single<[MemberMission.MissionDTO]> in
-                                let data = response.data
-                                let missions = data.missions
-                                self.retryCountRelay.accept(data.retryCount)
-                                if !missions.isEmpty {
-                                    return .just(missions)
-                                } else {
-                                    return self.missionService.requestRecommendedMultipleMissions(memberInterestIds: [id])
-                                        .map { multipleResponse in
-                                            self.retryCountRelay.accept(multipleResponse.data.retryCount)
-                                            return multipleResponse.data.missions.first?.data.map { $0.toMissionDTO() } ?? []
-                                        }
-                                }
-                            }
+                return self.resolveMissionSource()
+                    .flatMap { source in
+                        self.missionService.requestRecommendedMultipleMissions(
+                            memberInterestIds: source.recommendationMemberInterestIds
+                        )
+                        .map { response in
+                            self.retryCountRelay.accept(response.data.retryCount)
+                            return Self.recommendedMissionDTOs(from: response, source: source)
+                        }
                     }
                     .asObservable()
                     .catch { err in
@@ -112,6 +105,8 @@ final class TodayMissionListViewModel {
                     }
                     .do(onDispose: { loadingSubject.onNext(false) })
             }
+
+        Observable.merge(injectedInitialLoad, apiLoad)
             .subscribe(onNext: { [weak self] missions in
                 guard let self = self else { return }
                 loadingSubject.onNext(false)
@@ -130,19 +125,22 @@ final class TodayMissionListViewModel {
                 let selectedMissions = currentMissions.filter { selectedIDs.contains($0.memberMissionId) }
                 let selectedMissionsIds = selectedMissions.map { $0.memberMissionId }
                 
-                return self.resolveMemberInterestId()
-                    .flatMap { id -> Single<MemberMission.RetryRecommendResponseDTO> in
-                        // API 호출: 선택된 미션들의 ID를 보냄
-                        self.missionService.retryRecommendMissions(memberInterestId: id, excludeMissionIDs: selectedMissionsIds)
+                return self.resolveMissionSource()
+                    .flatMap { source -> Single<(MissionSource, MemberMission.RetryRecommendResponseDTO)> in
+                        let excludeMissionIDs = source.shouldSendRetryExcludeMissionIds ? selectedMissionsIds : nil
+                        return self.missionService.retryRecommendMissions(
+                            memberInterestId: source.retryMemberInterestId,
+                            excludeMissionIDs: excludeMissionIDs
+                        )
+                        .map { (source, $0) }
                     }
                     .asObservable()
-                    .map { (response: MemberMission.RetryRecommendResponseDTO) -> [MemberMission.MissionDTO] in
+                    .map { (source, response) -> [MemberMission.MissionDTO] in
                         let data = response.data
                         
                         self.retryCountRelay.accept(data.retryCount)
                         
-                        let newRetryMissions = data.missions.first?.data ?? [] // 현재 가장 첫번째 값으로 구현
-                        let newMissions = newRetryMissions.map { $0.toMissionDTO() }
+                        let newMissions = Self.retryMissionDTOs(from: response, source: source)
                         
                         let needCount = max(0, 5 - selectedMissions.count)
                         let missionsToAdd = Array(newMissions.prefix(needCount))
@@ -240,25 +238,51 @@ final class TodayMissionListViewModel {
         )
     }
     
-    private func resolveMemberInterestId() -> Single<Int> {
-        // UserDefaults에 저장된 값 사용
+    private func resolveMissionSource() -> Single<MissionSource> {
+        if chatbotMissions != nil || UserDefaultsManager.shared.usesChatbotGoalMissions {
+            return .just(.chatbot)
+        }
+
         if let saved = UserDefaultsManager.shared.selectedMemberInterestId {
-            return .just(saved)
+            return .just(MissionSource(memberInterestIds: [saved]))
         }
 
         // 없을 시 서버에 요청
         return interestsService.fetchInterests()
-            .map { dto -> Int in
-                guard let id = dto.interests.first?.memberInterestId else {
-                    // 챗봇 사용자는 관심사가 없음 → goalBased interestId(0)로 조회
-                    return 0
+            .map { dto -> MissionSource in
+                let source = MissionSource(memberInterestIds: dto.interests.map(\.memberInterestId))
+
+                switch source {
+                case .chatbot:
+                    UserDefaultsManager.shared.usesChatbotGoalMissions = true
+                case .interest(let ids):
+                    UserDefaultsManager.shared.selectedMemberInterestId = ids.first
                 }
-                UserDefaultsManager.shared.selectedMemberInterestId = id
-                return id
+
+                return source
             }
-            .catch { _ in
-                // API 오류(네트워크, 인증 등) 발생 시에도 goalBased interestId(0)로 폴백
-                return .just(0)
+    }
+
+    private static func recommendedMissionDTOs(
+        from response: MemberMission.RecommendMultipleResponseDTO,
+        source: MissionSource
+    ) -> [MemberMission.MissionDTO] {
+        let targetIDs = Set(source.recommendationMemberInterestIds)
+
+        return response.data.missions
+            .filter { targetIDs.contains($0.memberInterestId) }
+            .flatMap { group in
+                group.data.map { $0.toMissionDTO() }
             }
+    }
+
+    private static func retryMissionDTOs(
+        from response: MemberMission.RetryRecommendResponseDTO,
+        source: MissionSource
+    ) -> [MemberMission.MissionDTO] {
+        response.data.missions
+            .first { $0.memberInterestId == source.retryMemberInterestId }?
+            .data
+            .map { $0.toMissionDTO() } ?? []
     }
 }

--- a/HaruUpTests/TodayMissionListViewModelTests.swift
+++ b/HaruUpTests/TodayMissionListViewModelTests.swift
@@ -1,0 +1,333 @@
+//
+//  TodayMissionListViewModelTests.swift
+//  HaruUpTests
+//
+//  Created by Codex on 6/24/26.
+//
+
+import XCTest
+import RxSwift
+@testable import HaruUp
+
+final class TodayMissionListViewModelTests: XCTestCase {
+    private var disposeBag: DisposeBag!
+
+    override func setUp() {
+        super.setUp()
+        disposeBag = DisposeBag()
+        resetMissionSourceDefaults()
+    }
+
+    override func tearDown() {
+        resetMissionSourceDefaults()
+        disposeBag = nil
+        super.tearDown()
+    }
+
+    func test_chatbotCompletionMissionsAreShownWithoutRecommendRequest() {
+        let missionService = MissionServiceSpy()
+        let viewModel = makeViewModel(
+            missionService: missionService,
+            chatbotMissions: [makeChatbotMission(id: 101)]
+        )
+        let input = makeInput()
+        var observedMissionIDs: [[Int]] = []
+
+        viewModel.transform(input: input.value)
+            .missions
+            .subscribe(onNext: { missions in
+                observedMissionIDs.append(missions.map(\.memberMissionId))
+            })
+            .disposed(by: disposeBag)
+
+        input.viewDidLoad.onNext(())
+
+        XCTAssertEqual(observedMissionIDs.last, [101])
+        XCTAssertTrue(missionService.singleRecommendRequests.isEmpty)
+        XCTAssertTrue(missionService.recommendMultipleRequests.isEmpty)
+    }
+
+    func test_emptyChatbotCompletionMissionsShowEmptyStateWithoutRecommendRequest() {
+        let missionService = MissionServiceSpy()
+        let viewModel = makeViewModel(
+            missionService: missionService,
+            chatbotMissions: []
+        )
+        let input = makeInput()
+        var observedMissionIDs: [[Int]] = []
+
+        viewModel.transform(input: input.value)
+            .missions
+            .subscribe(onNext: { missions in
+                observedMissionIDs.append(missions.map(\.memberMissionId))
+            })
+            .disposed(by: disposeBag)
+
+        input.viewDidLoad.onNext(())
+
+        XCTAssertEqual(observedMissionIDs.last, [])
+        XCTAssertTrue(missionService.singleRecommendRequests.isEmpty)
+        XCTAssertTrue(missionService.recommendMultipleRequests.isEmpty)
+    }
+
+    func test_chatbotRequeryRequestsRecommendWithOnlyChatbotGoalInterestId() {
+        UserDefaultsManager.shared.usesChatbotGoalMissions = true
+        let missionService = MissionServiceSpy()
+        missionService.recommendMultipleMissionIDs = [201, 202]
+        let viewModel = makeViewModel(missionService: missionService)
+        let input = makeInput()
+        var observedMissionIDs: [[Int]] = []
+
+        viewModel.transform(input: input.value)
+            .missions
+            .subscribe(onNext: { missions in
+                observedMissionIDs.append(missions.map(\.memberMissionId))
+            })
+            .disposed(by: disposeBag)
+
+        input.viewDidLoad.onNext(())
+
+        XCTAssertEqual(missionService.recommendMultipleRequests, [[MissionSource.chatbotGoalInterestId]])
+        XCTAssertTrue(missionService.singleRecommendRequests.isEmpty)
+        XCTAssertEqual(observedMissionIDs.last, [201, 202])
+    }
+
+    func test_chatbotRetryRequestsGoalInterestIdAndOmitsExcludedMissionIds() {
+        let missionService = MissionServiceSpy()
+        let viewModel = makeViewModel(
+            missionService: missionService,
+            chatbotMissions: [makeChatbotMission(id: 301)]
+        )
+        let input = makeInput()
+
+        viewModel.transform(input: input.value)
+            .missions
+            .subscribe()
+            .disposed(by: disposeBag)
+
+        input.viewDidLoad.onNext(())
+        input.missionSelected.onNext(301)
+        input.retryRecommend.onNext(())
+
+        XCTAssertEqual(missionService.retryRequests.map(\.memberInterestId), [MissionSource.chatbotGoalInterestId])
+        XCTAssertNil(missionService.retryRequests.first?.excludeMissionIDs)
+    }
+
+    func test_interestRequeryUsesRealInterestIdWithoutMixingChatbotGoalId() {
+        UserDefaultsManager.shared.selectedMemberInterestId = 42
+        let missionService = MissionServiceSpy()
+        missionService.recommendMultipleMissionIDs = [401]
+        let viewModel = makeViewModel(missionService: missionService)
+        let input = makeInput()
+
+        viewModel.transform(input: input.value)
+            .missions
+            .subscribe()
+            .disposed(by: disposeBag)
+
+        input.viewDidLoad.onNext(())
+
+        XCTAssertEqual(missionService.recommendMultipleRequests, [[42]])
+        XCTAssertFalse(missionService.recommendMultipleRequests.contains([MissionSource.chatbotGoalInterestId, 42]))
+        XCTAssertTrue(missionService.singleRecommendRequests.isEmpty)
+    }
+
+    func test_interestRetryKeepsRealInterestIdAndSendsSelectedMissionIdsAsExcludeList() {
+        UserDefaultsManager.shared.selectedMemberInterestId = 42
+        let missionService = MissionServiceSpy()
+        missionService.recommendMultipleMissionIDs = [501]
+        let viewModel = makeViewModel(missionService: missionService)
+        let input = makeInput()
+
+        viewModel.transform(input: input.value)
+            .missions
+            .subscribe()
+            .disposed(by: disposeBag)
+
+        input.viewDidLoad.onNext(())
+        input.missionSelected.onNext(501)
+        input.retryRecommend.onNext(())
+
+        XCTAssertEqual(missionService.retryRequests.map(\.memberInterestId), [42])
+        XCTAssertEqual(missionService.retryRequests.first?.excludeMissionIDs, [501])
+    }
+}
+
+private extension TodayMissionListViewModelTests {
+    typealias InputSubjects = (
+        viewDidLoad: PublishSubject<Void>,
+        refreshTap: PublishSubject<Void>,
+        completeTap: PublishSubject<Void>,
+        missionSelected: PublishSubject<Int>,
+        retryRecommend: PublishSubject<Void>,
+        value: TodayMissionListViewModel.Input
+    )
+
+    func makeInput() -> InputSubjects {
+        let viewDidLoad = PublishSubject<Void>()
+        let refreshTap = PublishSubject<Void>()
+        let completeTap = PublishSubject<Void>()
+        let missionSelected = PublishSubject<Int>()
+        let retryRecommend = PublishSubject<Void>()
+
+        return (
+            viewDidLoad: viewDidLoad,
+            refreshTap: refreshTap,
+            completeTap: completeTap,
+            missionSelected: missionSelected,
+            retryRecommend: retryRecommend,
+            value: TodayMissionListViewModel.Input(
+                viewDidLoad: viewDidLoad.asObservable(),
+                refreshTap: refreshTap.asObservable(),
+                completeTap: completeTap.asObservable(),
+                missionSelected: missionSelected.asObservable(),
+                retryRecommend: retryRecommend.asObservable()
+            )
+        )
+    }
+
+    func makeViewModel(
+        missionService: MissionServiceSpy,
+        chatbotMissions: [ChatbotMissionDto]? = nil
+    ) -> TodayMissionListViewModel {
+        TodayMissionListViewModel(
+            missionService: missionService,
+            interestsService: InterestsService(),
+            chatbotMissions: chatbotMissions
+        )
+    }
+
+    func makeChatbotMission(id: Int) -> ChatbotMissionDto {
+        ChatbotMissionDto(
+            id: id,
+            missionContent: "챗봇 미션 \(id)",
+            missionDescription: "설명 \(id)",
+            difficulty: 2,
+            expEarned: 10
+        )
+    }
+
+    func resetMissionSourceDefaults() {
+        UserDefaultsManager.shared.selectedMemberInterestId = nil
+        UserDefaultsManager.shared.usesChatbotGoalMissions = false
+    }
+}
+
+private final class MissionServiceSpy: MissionServiceProtocol {
+    struct RetryRequest {
+        let memberInterestId: Int
+        let excludeMissionIDs: [Int]?
+    }
+
+    var singleRecommendRequests: [Int] = []
+    var recommendMultipleRequests: [[Int]] = []
+    var retryRequests: [RetryRequest] = []
+
+    var recommendMultipleMissionIDs: [Int] = []
+    var retryMissionIDs: [Int] = [901, 902, 903, 904, 905]
+
+    func requestRecommendedMissions(memberInterestId: Int) -> Single<MemberMission.MissionRecommendResponseDTO> {
+        singleRecommendRequests.append(memberInterestId)
+        return .just(MemberMission.MissionRecommendResponseDTO(
+            success: true,
+            data: MemberMission.MissionsDTO(missions: [], retryCount: 0),
+            errorMessage: nil
+        ))
+    }
+
+    func requestRecommendedMultipleMissions(memberInterestIds: [Int]) -> Single<MemberMission.RecommendMultipleResponseDTO> {
+        recommendMultipleRequests.append(memberInterestIds)
+        let responseGroups = memberInterestIds.map { memberInterestId in
+            MemberMission.MultipleMissionsDTO(
+                memberInterestId: memberInterestId,
+                data: recommendMultipleMissionIDs.map { makeMultipleMission(id: $0) }
+            )
+        }
+
+        return .just(MemberMission.RecommendMultipleResponseDTO(
+            success: true,
+            data: MemberMission.MultipleDataDTO(
+                missions: responseGroups,
+                totalCount: recommendMultipleMissionIDs.count,
+                retryCount: 0
+            ),
+            errorMessage: nil
+        ))
+    }
+
+    func retryRecommendMissions(memberInterestId: Int, excludeMissionIDs: [Int]?) -> Single<MemberMission.RetryRecommendResponseDTO> {
+        retryRequests.append(RetryRequest(memberInterestId: memberInterestId, excludeMissionIDs: excludeMissionIDs))
+        return .just(MemberMission.RetryRecommendResponseDTO(
+            success: true,
+            data: MemberMission.RetryMissionsDTO(
+                missions: [
+                    MemberMission.RetryMissionsResponseDTO(
+                        memberInterestId: memberInterestId,
+                        data: retryMissionIDs.map { makeRetryMission(id: $0) }
+                    )
+                ],
+                totalCount: retryMissionIDs.count,
+                retryCount: 1
+            ),
+            errorMessage: nil
+        ))
+    }
+
+    func selectMissions(missionIDs: [Int]) -> Single<MemberMission.SelectMissionResponseDTO> {
+        .just(MemberMission.SelectMissionResponseDTO(success: true, data: missionIDs, errorMessage: nil))
+    }
+
+    func fetchMissionList(
+        memberInterestId: Int?,
+        targetDate: String,
+        status: [MemberMission.MissionStatusType]
+    ) -> Single<MemberMission.FetchMissionResponseDTO> {
+        .just(MemberMission.FetchMissionResponseDTO(success: true, data: [], errorMessage: nil))
+    }
+
+    func setMissionStatus(id: Int, status: String) -> Single<MemberMission.MissionStatusResponseDTO> {
+        .just(MemberMission.MissionStatusResponseDTO(success: true, data: status, errorMessage: nil))
+    }
+
+    func fetchChallengeDate() -> Single<MemberMission.ChallengeResponseDTO> {
+        .just(MemberMission.ChallengeResponseDTO(success: true, data: [], errorMessage: nil))
+    }
+
+    func fetchMonthlyMissions(targetMonth: String) -> Single<MemberMission.HistoryResponseDTO> {
+        .just(MemberMission.HistoryResponseDTO(
+            success: true,
+            data: MemberMission.HistoryDTO(missionCounts: [], totalMissionCount: 0, totalCompletedDays: 0),
+            errorMessage: nil
+        ))
+    }
+
+    func fetchGrowthChart() -> Single<MemberMission.GrowthResponseDTO> {
+        .just(MemberMission.GrowthResponseDTO(
+            success: true,
+            data: MemberMission.GrowthDataDTO(monthlyData: []),
+            errorMessage: nil
+        ))
+    }
+
+    private func makeMultipleMission(id: Int) -> MemberMission.MultipleMissionDTO {
+        MemberMission.MultipleMissionDTO(
+            memberMissionId: id,
+            content: "추천 미션 \(id)",
+            directFullPath: [],
+            difficulty: 2,
+            expEarned: 10,
+            createdType: "AI"
+        )
+    }
+
+    private func makeRetryMission(id: Int) -> MemberMission.RetryMissionDTO {
+        MemberMission.RetryMissionDTO(
+            memberMissionId: id,
+            content: "재추천 미션 \(id)",
+            directFullPath: [],
+            difficulty: 2,
+            expEarned: 10,
+            createdType: "AI"
+        )
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 챗봇 목표 기반 미션과 관심사 기반 미션을 명확히 구분하지 못함.
- 추천/재추천 조회가 정상 동작하지 않던 문제를 개선