### PR TITLE
feat: AdMob 배너 광고 및 UMP 동의/ATT 플로우 추가

### DIFF
--- a/HaruUp.xcodeproj/project.pbxproj
+++ b/HaruUp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		4893D23F2ED9771B0018D43A /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 4893D23E2ED9771B0018D43A /* KakaoSDKUser */; };
 		4893D2452ED985650018D43A /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 4893D2442ED985650018D43A /* RxCocoa */; };
 		4893D2472ED985650018D43A /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 4893D2462ED985650018D43A /* RxSwift */; };
+		489DC0A73028759300C80F20 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 489DC0A63028759300C80F20 /* GoogleMobileAds */; };
 		7A00000C2F5000000010000C /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 4893D2462ED985650018D43A /* RxSwift */; };
 		CF46F20A2F2A159800CDCCDE /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = CF46F2092F2A159800CDCCDE /* FirebaseCore */; };
 		CFC7F0942F47FD0800BCF147 /* AmplitudeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CFC7F0932F47FD0800BCF147 /* AmplitudeSwift */; };
@@ -71,6 +72,7 @@
 				480A9BDE2EF9E63F00E9B443 /* Lottie in Frameworks */,
 				4893D23B2ED9771B0018D43A /* KakaoSDKAuth in Frameworks */,
 				4893D2472ED985650018D43A /* RxSwift in Frameworks */,
+				489DC0A73028759300C80F20 /* GoogleMobileAds in Frameworks */,
 				4893D2452ED985650018D43A /* RxCocoa in Frameworks */,
 				4893D23F2ED9771B0018D43A /* KakaoSDKUser in Frameworks */,
 				CF46F20A2F2A159800CDCCDE /* FirebaseCore in Frameworks */,
@@ -146,6 +148,7 @@
 				CF46F2092F2A159800CDCCDE /* FirebaseCore */,
 				48433DD02F2A38F9004AC7DB /* FirebaseMessaging */,
 				CFC7F0932F47FD0800BCF147 /* AmplitudeSwift */,
+				489DC0A63028759300C80F20 /* GoogleMobileAds */,
 			);
 			productName = HaruUp;
 			productReference = 4893D1EC2ED6E2AE0018D43A /* HaruUp.app */;
@@ -210,6 +213,7 @@
 				480A9BDC2EF9E63F00E9B443 /* XCRemoteSwiftPackageReference "lottie-spm" */,
 				CF46F2072F2A153000CDCCDE /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				CFC7F0922F47FD0800BCF147 /* XCRemoteSwiftPackageReference "Amplitude-Swift" */,
+				489DC0A0302229A600C80F20 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 4893D1ED2ED6E2AE0018D43A /* Products */;
@@ -563,6 +567,14 @@
 				minimumVersion = 6.9.1;
 			};
 		};
+		489DC0A0302229A600C80F20 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/googleads/swift-package-manager-google-mobile-ads.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 13.7.0;
+			};
+		};
 		CF46F2072F2A153000CDCCDE /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
@@ -621,6 +633,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4893D2432ED985650018D43A /* XCRemoteSwiftPackageReference "RxSwift" */;
 			productName = RxSwift;
+		};
+		489DC0A63028759300C80F20 /* GoogleMobileAds */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 489DC0A0302229A600C80F20 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */;
+			productName = GoogleMobileAds;
 		};
 		CF46F2092F2A159800CDCCDE /* FirebaseCore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/HaruUp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HaruUp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "709739abad71e71778fe47ef6dd130d5e7a590280e4d9b4cbdee3eb8f9d0bb21",
+  "originHash" : "318e252f90627262bdbabd68e687cb6bf141e170b751f9479a46cbfba3983f4e",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -188,6 +188,24 @@
       "state" : {
         "revision" : "5004a18539bd68905c5939aa893075f578f4f03d",
         "version" : "6.9.1"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-mobile-ads",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
+      "state" : {
+        "revision" : "868149fc50d1452078e83540e636cf519bac3e6a",
+        "version" : "13.7.0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-user-messaging-platform",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
+      "state" : {
+        "revision" : "13b248eaa73b7826f0efb1bcf455e251d65ecb1b",
+        "version" : "3.1.0"
       }
     }
   ],

--- a/HaruUp/Application/AppDelegate.swift
+++ b/HaruUp/Application/AppDelegate.swift
@@ -15,6 +15,7 @@ import FirebaseCore
 import FirebaseMessaging
 import UserNotifications
 import AmplitudeSwift
+import GoogleMobileAds
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -23,7 +24,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     static var amplitude: Amplitude?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        
+
+        // Google Mobile Ads SDK 초기화
+        MobileAds.shared.start()
+
         // App 최초 실행 여부
         TokenStorageService.shared.checkFirstLaunch()
         

--- a/HaruUp/Application/Info.plist
+++ b/HaruUp/Application/Info.plist
@@ -110,5 +110,16 @@
 	<array>
 		<string>remote-notification</string>
 	</array>
+    <key>GADApplicationIdentifier</key>
+    <string>ca-app-pub-3940256099942544~1458002511</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>맞춤형 광고를 제공하기 위해 사용자의 활동 데이터를 사용합니다.</string>
+    <key>SKAdNetworkItems</key>
+    <array>
+        <dict>
+            <key>SKAdNetworkIdentifier</key>
+            <string>cstr6suwn9.skadnetwork</string>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/HaruUp/Network/Service/Ad/AdConsentManager.swift
+++ b/HaruUp/Network/Service/Ad/AdConsentManager.swift
@@ -1,0 +1,71 @@
+//
+//  AdConsentManager.swift
+//  HaruUp
+//
+//  Created by 하다현 on 8/9/26.
+//
+
+import GoogleMobileAds
+import UserMessagingPlatform
+import AppTrackingTransparency
+import UIKit
+
+final class AdConsentManager {
+    static let shared = AdConsentManager()
+    private init() {}
+
+    private var isMobileAdsStarted = false
+
+    /// 첫 화면의 viewDidAppear에서 이 함수 하나만 호출하면 됩니다.
+    func requestConsentAndInitializeAds(from viewController: UIViewController,
+                                         completion: @escaping () -> Void) {
+        let parameters = RequestParameters()
+
+        // ① 동의 정보 업데이트 요청 (앱 실행할 때마다 호출)
+        ConsentInformation.shared.requestConsentInfoUpdate(with: parameters) { [weak self] error in
+            guard let self else { return }
+            if let error {
+                print("[AdConsentManager] 동의 정보 업데이트 실패: \(error.localizedDescription)")
+            }
+
+            // ② 필요한 경우에만 동의 폼을 자동으로 띄워줌 (EEA/영국 사용자 등)
+            ConsentForm.loadAndPresentIfRequired(from: viewController) { formError in
+                if let formError {
+                    print("[AdConsentManager] 동의 폼 표시 실패: \(formError.localizedDescription)")
+                }
+
+                // ③ 동의 절차가 끝난 뒤 ATT 권한 요청
+                self.requestTrackingAuthorization {
+                    // ④ SDK 초기화 확정 + ⑤ 광고 로드 가능 여부 콜백
+                    self.startGoogleMobileAdsSDK(completion: completion)
+                }
+            }
+        }
+    }
+
+    private func requestTrackingAuthorization(completion: @escaping () -> Void) {
+        if #available(iOS 14, *) {
+            ATTrackingManager.requestTrackingAuthorization { _ in
+                DispatchQueue.main.async { completion() }
+            }
+        } else {
+            completion()
+        }
+    }
+
+    private func startGoogleMobileAdsSDK(completion: @escaping () -> Void) {
+        guard !isMobileAdsStarted else {
+            completion()
+            return
+        }
+        // 사용자가 동의하지 않아 광고를 요청할 수 없는 상태면 여기서 걸러짐
+        guard ConsentInformation.shared.canRequestAds else {
+            completion()
+            return
+        }
+        isMobileAdsStarted = true
+        MobileAds.shared.start { _ in
+            DispatchQueue.main.async { completion() }
+        }
+    }
+}

--- a/HaruUp/Network/Service/Ad/AdManager.swift
+++ b/HaruUp/Network/Service/Ad/AdManager.swift
@@ -1,0 +1,15 @@
+//
+//  AdManager.swift
+//  HaruUp
+//
+//  Created by 하다현 on 8/9/26.
+//
+
+import GoogleMobileAds
+
+final class AdManager {
+    static let shared = AdManager()
+    private init() {}
+
+    let bannerTestUnitID = "ca-app-pub-3940256099942544/2934735716"
+}

--- a/HaruUp/Presentation/Home/HomeViewController.swift
+++ b/HaruUp/Presentation/Home/HomeViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import RxSwift
 import RxCocoa
+import GoogleMobileAds
 
 class HomeViewController: UIViewController {
     
@@ -47,8 +48,17 @@ class HomeViewController: UIViewController {
     }()
     
     private let headerView = HomeHeaderView()
-    
+
     private weak var sectionHeaderView: HomeSectionHeaderView?
+
+    private lazy var bannerView: BannerView = {
+        let banner = BannerView(adSize: AdSizeBanner)
+        banner.adUnitID = AdManager.shared.bannerTestUnitID
+        banner.rootViewController = self
+        return banner
+    }()
+
+    private let bannerFooterView = UIView()
     
     // MARK: - LifeCycle
     init(viewModel: HomeViewModel) {
@@ -80,6 +90,7 @@ class HomeViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         viewDidAppearRelay.accept(())
+        loadBannerAd()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -102,26 +113,46 @@ class HomeViewController: UIViewController {
     private func configureTableView() {
         view.addSubview(tableView)
         tableView.translatesAutoresizingMaskIntoConstraints = false
-        
+
         headerView.onTapChallenge = { [weak self] in
             guard let self = self else { return }
-            
+
             self.onShowChallengeBottomSheet?(self.challengeCount, self.challengeData)
         }
-        
+
         tableView.tableHeaderView = headerView
         tableView.sectionHeaderTopPadding = 28 // Section Header와 TableView Header의 간격
-        
+
         tableView.delegate = self
-        
+
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
-        
+
+        configureBannerFooterView()
         updateTableHeaderHeight()
+    }
+
+    private func configureBannerFooterView() {
+        bannerFooterView.addSubview(bannerView)
+        bannerView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            bannerView.centerXAnchor.constraint(equalTo: bannerFooterView.centerXAnchor),
+            bannerView.topAnchor.constraint(equalTo: bannerFooterView.topAnchor, constant: 8),
+            bannerView.bottomAnchor.constraint(equalTo: bannerFooterView.bottomAnchor, constant: -8)
+        ])
+
+        // tableFooterView는 AutoLayout이 아니라 frame으로 높이가 결정되어 직접 지정
+        bannerFooterView.frame = CGRect(x: 0, y: 0, width: 0, height: 66)
+        tableView.tableFooterView = bannerFooterView
+    }
+
+    private func loadBannerAd() {
+        bannerView.load(Request())
     }
     
     private func updateTableHeaderHeight() {

--- a/HaruUp/Presentation/LoginScreen/LoginViewController.swift
+++ b/HaruUp/Presentation/LoginScreen/LoginViewController.swift
@@ -60,9 +60,17 @@ class LoginViewController: UIViewController {
     // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         setupView()
         bind()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        AdConsentManager.shared.requestConsentAndInitializeAds(from: self) {
+            // 로그인 화면에서는 광고를 안 띄울 거라 여기선 딱히 할 일 없음
+        }
     }
     
     func setupView() {

--- a/HaruUp/Presentation/MyPage/MyPageViewController.swift
+++ b/HaruUp/Presentation/MyPage/MyPageViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import RxSwift
 import RxCocoa
+import GoogleMobileAds
 
 
 
@@ -139,6 +140,14 @@ class MyPageViewController: UIViewController {
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
+
+    private lazy var bannerView: BannerView = {
+        let banner = BannerView(adSize: AdSizeBanner)
+        banner.adUnitID = AdManager.shared.bannerTestUnitID
+        banner.rootViewController = self
+        banner.translatesAutoresizingMaskIntoConstraints = false
+        return banner
+    }()
     
     init(viewModel: MyPageViewModel) {
         self.viewModel = viewModel
@@ -159,7 +168,12 @@ class MyPageViewController: UIViewController {
         super.viewWillDisappear(animated)
         navigationController?.setNavigationBarHidden(false, animated: animated)
     }
-    
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        loadBannerAd()
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
@@ -175,7 +189,7 @@ class MyPageViewController: UIViewController {
         view.addSubview(scrollView)
         scrollView.addSubview(contentView)
         
-        [titleLabel, profileImageView, nicknameLabel, editProfileButton, jobLabel, goalCardView, menuStackView, versionLabel].forEach {
+        [titleLabel, profileImageView, nicknameLabel, editProfileButton, jobLabel, goalCardView, menuStackView, bannerView, versionLabel].forEach {
             contentView.addSubview($0)
         }
         
@@ -192,6 +206,10 @@ class MyPageViewController: UIViewController {
         goalCardView.isHidden = true
         editInterestBtn.isHidden = true
         setupConstraints()
+    }
+
+    private func loadBannerAd() {
+        bannerView.load(Request())
     }
 
     private func setupConstraints() {
@@ -255,7 +273,10 @@ class MyPageViewController: UIViewController {
             menuStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
             menuStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
             
-            versionLabel.topAnchor.constraint(equalTo: menuStackView.bottomAnchor, constant: 10),
+            bannerView.topAnchor.constraint(equalTo: menuStackView.bottomAnchor, constant: 15),
+            bannerView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+
+            versionLabel.topAnchor.constraint(equalTo: bannerView.bottomAnchor, constant: 15),
             versionLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 40),
             versionLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -40)
         ])

--- a/HaruUp/Presentation/MyPage/MyPageViewModel.swift
+++ b/HaruUp/Presentation/MyPage/MyPageViewModel.swift
@@ -67,7 +67,7 @@ final class MyPageViewModel {
             })
             .disposed(by: disposeBag)
         
-        let version = Driver.just("버전.v.1.0.8")
+        let version = Driver.just("버전.v.1.0.10")
         
         // 로그아웃 Alert 표시
         let showLogoutAlert = input.logoutTapped


### PR DESCRIPTION
## 작업내용
- AppDelegate에서 Google Mobile Ads SDK 초기화
- AdConsentManager 추가: 로그인 화면 진입 시 UMP 동의 → ATT 권한 요청 → SDK 초기화 순으로 처리
- AdManager 추가: 배너 광고 단위 ID 관리 (현재 Google 공식 테스트 ID 사용 중)
- 홈 화면 리스트 하단에 배너 광고 배치 
- 마이페이지 탈퇴하기 버튼 하단에 배너 광고 배치

## Test plan
- [ ] 실제 기기/시뮬레이터에서 빌드 성공 확인
- [ ] 로그인 화면 진입 시 ATT 사전 안내 → 시스템 ATT 권한 팝업 순서로 뜨는지 확인
- [ ] 홈 화면 스크롤 최하단에서 테스트 배너 노출 확인
- [ ] 마이페이지 탈퇴하기 버튼 아래 테스트 배너 노출 확인
- [ ] 배포 전 실제 AdMob 앱 ID/광고 단위 ID로 교체 필요 (현재는 테스트 ID)
