### PR TITLE
Chore: AdMob 테스트 ID를 운영 ID로 교체 및 개인정보처리방침 갱신

### DIFF
--- a/HaruUp/Application/Info.plist
+++ b/HaruUp/Application/Info.plist
@@ -111,7 +111,7 @@
 		<string>remote-notification</string>
 	</array>
     <key>GADApplicationIdentifier</key>
-    <string>ca-app-pub-3940256099942544~1458002511</string>
+    <string>ca-app-pub-1764976097996466~1825062991</string>
     <key>NSUserTrackingUsageDescription</key>
     <string>맞춤형 광고를 제공하기 위해 사용자의 활동 데이터를 사용합니다.</string>
     <key>SKAdNetworkItems</key>

--- a/HaruUp/Network/Service/Ad/AdManager.swift
+++ b/HaruUp/Network/Service/Ad/AdManager.swift
@@ -11,5 +11,5 @@ final class AdManager {
     static let shared = AdManager()
     private init() {}
 
-    let bannerTestUnitID = "ca-app-pub-3940256099942544/2934735716"
+    let bannerAdUnitID = "ca-app-pub-1764976097996466/8385888876"
 }

--- a/HaruUp/Presentation/Home/HomeViewController.swift
+++ b/HaruUp/Presentation/Home/HomeViewController.swift
@@ -53,7 +53,7 @@ class HomeViewController: UIViewController {
 
     private lazy var bannerView: BannerView = {
         let banner = BannerView(adSize: AdSizeBanner)
-        banner.adUnitID = AdManager.shared.bannerTestUnitID
+        banner.adUnitID = AdManager.shared.bannerAdUnitID
         banner.rootViewController = self
         return banner
     }()

--- a/HaruUp/Presentation/MyPage/MyPageViewController.swift
+++ b/HaruUp/Presentation/MyPage/MyPageViewController.swift
@@ -143,7 +143,7 @@ class MyPageViewController: UIViewController {
 
     private lazy var bannerView: BannerView = {
         let banner = BannerView(adSize: AdSizeBanner)
-        banner.adUnitID = AdManager.shared.bannerTestUnitID
+        banner.adUnitID = AdManager.shared.bannerAdUnitID
         banner.rootViewController = self
         banner.translatesAutoresizingMaskIntoConstraints = false
         return banner
@@ -436,7 +436,7 @@ class MyPageViewController: UIViewController {
             .subscribe(with: self, onNext: { owner, _ in
                 AnalyticsManager.shared.track(event: AppEvent.MyPage.privacyPolicyTapped)
                 
-                guard let url = URL(string: "https://melodic-roar-3e1.notion.site/2e0849f596f380969043ee98e361c7bf") else { return }
+                guard let url = URL(string: "https://delightful-reply-8f4.notion.site/3c5829a940ae80528102f0ab06b285e8") else { return }
                 if UIApplication.shared.canOpenURL(url) {
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)
                 }


### PR DESCRIPTION
## 작업내용
- Info.plist: GADApplicationIdentifier를 실제 AdMob 앱 ID로 교체
- AdManager: bannerTestUnitID → bannerAdUnitID로 변경, 실제 배너 광고 단위 ID 적용
- HomeViewController/MyPageViewController: 변경된 프로퍼티명 반영
- MyPageViewController: 개인정보처리방침 링크를 AdMob(광고 식별자 수집) 고지가 포함된 새 문서로 교체