### PR TITLE
feat: 개편된 큐레이션 API에 맞춰 챗봇 화면 갱신

### DIFF
--- a/HaruUp/Data/Models/Curation/ChatbotModels.swift
+++ b/HaruUp/Data/Models/Curation/ChatbotModels.swift
@@ -18,28 +18,41 @@ struct ChatbotSetupRequest: Encodable {
     let nickname: String
 }
 
+// POST /api/character/personality 에 보낼 body
+struct SelectPersonalityRequest: Encodable {
+    let personality: String
+}
+
+// ── 성격 ──────────────────────────────────
+// GET /api/character/personality/list 응답 항목
+struct PersonalityData: Codable {
+    let code: String        // 선택 시 그대로 돌려보낼 값 (WARM_FRIEND / CLEAR_COACH)
+    let label: String       // 사용자에게 보여줄 문구
+}
+
 // ── 응답 ──────────────────────────────────
+/// 질문 유형. 서버가 새 값을 추가해도 앱이 죽지 않도록 unknown 으로 흡수한다.
+enum ChatbotQuestionType: String, Codable {
+    case aiFollowUp = "AI_FOLLOW_UP"    // AI가 대화 맥락에 맞춰 만든 꼬리질문
+    case fixedTime = "FIXED_TIME"       // 투자 가능 시간을 묻는 고정 질문
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = ChatbotQuestionType(rawValue: raw) ?? .unknown
+    }
+}
+
 // POST /chatbot/start 응답
 struct ChatbotStartData: Codable {
     let sessionId: String
     let question: String
+    /// 첫 질문에서는 항상 비어 있다.
+    /// 사용자가 예시를 그대로 골라 목표가 구체화되지 않는 문제 때문에 서버가 선택지를 주지 않는다.
     let examples: [String]
+    /// 입력창에 표시할 예시 (고를 수 없음)
+    let placeholder: String?
     let questionNumber: Int
-}
-
-// POST /chatbot/answer 응답 — 진행 중 (Q2~Q5)
-struct ChatbotNextQuestionData: Codable {
-    let sessionId: String
-    let question: String
-    let questionNumber: Int
-    let isLast: Bool           // true면 마지막 질문 안내 가능
-}
-
-// POST /chatbot/answer 응답 — 완료 (Q6 답변 후)
-struct ChatbotCompleteData: Codable {
-    let isCompleted: Bool
-    let goalText: String
-    let missions: [ChatbotMissionDto]
 }
 
 struct ChatbotMissionDto: Codable {
@@ -50,16 +63,50 @@ struct ChatbotMissionDto: Codable {
     let expEarned: Int
 }
 
-// answer API는 진행 중/완료 두 가지 응답이 올 수 있어서
-// 하나의 통합 모델로 처리 (모든 필드 optional)
+/// answer API 는 네 가지 응답이 올 수 있어 하나의 모델로 받는다.
+/// 어떤 응답인지는 `kind` 로 판별한다.
 struct ChatbotAnswerResultData: Codable {
-    // 진행 중 필드
+    // 공통
     let sessionId: String?
+
+    // 진행 중 (다음 꼬리질문 또는 투자 가능 시간 질문)
     let question: String?
+    let examples: [String]?
     let questionNumber: Int?
     let isLast: Bool?
-    // 완료 필드
+    let questionType: ChatbotQuestionType?
+
+    // 목표 검증 실패 (목표를 2개 이상 입력한 경우)
+    let isValidGoal: Bool?
+    let message: String?
+    let detectedGoals: [String]?
+
+    // 마무리 확인 (정보가 충분히 모였을 때)
+    let awaitingFinishConfirmation: Bool?
+    let answeredCount: Int?
+
+    // 완료
     let isCompleted: Bool?
     let goalText: String?
     let missions: [ChatbotMissionDto]?
+
+    /// 마무리 확인과 완료 응답 모두 사용자에게 보여줄 짧은 요약을 내려준다.
+    let summary: String?
+
+    /// 서버 응답 종류
+    enum Kind {
+        case goalRejected       // 목표를 하나만 입력하도록 되돌리기
+        case finishConfirm      // 요약을 보여주고 마무리할지 묻기
+        case nextQuestion       // 다음 질문 표시
+        case completed          // 대화 종료, 미션 생성 완료
+        case unknown
+    }
+
+    var kind: Kind {
+        if isCompleted == true { return .completed }
+        if isValidGoal == false { return .goalRejected }
+        if awaitingFinishConfirmation == true { return .finishConfirm }
+        if question != nil { return .nextQuestion }
+        return .unknown
+    }
 }

--- a/HaruUp/Data/Models/Curation/ChatbotModels.swift
+++ b/HaruUp/Data/Models/Curation/ChatbotModels.swift
@@ -23,6 +23,14 @@ struct SelectPersonalityRequest: Encodable {
     let personality: String
 }
 
+// ── 캐릭터 ────────────────────────────────
+// GET /api/character/list 응답 항목 (배열로 그대로 내려온다)
+struct CharacterData: Codable {
+    let id: Int
+    let name: String?
+    let description: String?
+}
+
 // ── 성격 ──────────────────────────────────
 // GET /api/character/personality/list 응답 항목
 struct PersonalityData: Codable {

--- a/HaruUp/Network/Service/Curation/CharacterService.swift
+++ b/HaruUp/Network/Service/Curation/CharacterService.swift
@@ -1,0 +1,38 @@
+//
+//  CharacterService.swift
+//  HaruUp
+//
+
+import Foundation
+import RxSwift
+import Alamofire
+
+/// 캐릭터 목록과 AI 성격을 다루는 API.
+final class CharacterService: Service {
+
+    private func authHeader() -> Alamofire.HTTPHeaders {
+        var headers: HTTPHeaders = ["Content-type": "application/json"]
+
+        if let token = TokenStorageService.shared.getRefreshToken() {
+            headers.add(name: "jwt-token", value: token)
+        }
+        return headers
+    }
+
+    /// 선택 가능한 캐릭터 목록.
+    /// 이 API 는 다른 API 와 달리 배열을 그대로 반환한다.
+    func characterList() -> Single<[CharacterData]> {
+        return request(NetworkDefine.CharacterAPI.list.url, method: .get, header: authHeader())
+    }
+
+    /// 선택 가능한 AI 성격 목록
+    func personalityList() -> Single<GenericResponse<[PersonalityData]>> {
+        return request(NetworkDefine.CharacterAPI.personalityList.url, method: .get, header: authHeader())
+    }
+
+    /// AI 성격 선택 (캐릭터 선택 이후, 챗봇 시작 전)
+    func selectPersonality(_ code: String) -> Single<GenericResponse<String>> {
+        let body = SelectPersonalityRequest(personality: code)
+        return request(NetworkDefine.CharacterAPI.selectPersonality.url, method: .post, header: authHeader(), body: body)
+    }
+}

--- a/HaruUp/Network/Service/Curation/ChatbotService.swift
+++ b/HaruUp/Network/Service/Curation/ChatbotService.swift
@@ -37,4 +37,15 @@ final class ChatbotService: Service {
         let body = ChatbotSetupRequest(characterId: characterId, nickname: nickname)
         return request(NetworkDefine.ChatbotAPI.chatbotSetup.url, method: .post, header: authHeader(), body: body)
     }
+
+    // 선택 가능한 AI 성격 목록
+    func personalityList() -> Single<GenericResponse<[PersonalityData]>> {
+        return request(NetworkDefine.CharacterAPI.personalityList.url, method: .get, header: authHeader())
+    }
+
+    // AI 성격 선택 (캐릭터 선택 이후, 챗봇 시작 전)
+    func selectPersonality(_ code: String) -> Single<GenericResponse<String>> {
+        let body = SelectPersonalityRequest(personality: code)
+        return request(NetworkDefine.CharacterAPI.selectPersonality.url, method: .post, header: authHeader(), body: body)
+    }
 }

--- a/HaruUp/Network/Service/Curation/ChatbotService.swift
+++ b/HaruUp/Network/Service/Curation/ChatbotService.swift
@@ -37,15 +37,4 @@ final class ChatbotService: Service {
         let body = ChatbotSetupRequest(characterId: characterId, nickname: nickname)
         return request(NetworkDefine.ChatbotAPI.chatbotSetup.url, method: .post, header: authHeader(), body: body)
     }
-
-    // 선택 가능한 AI 성격 목록
-    func personalityList() -> Single<GenericResponse<[PersonalityData]>> {
-        return request(NetworkDefine.CharacterAPI.personalityList.url, method: .get, header: authHeader())
-    }
-
-    // AI 성격 선택 (캐릭터 선택 이후, 챗봇 시작 전)
-    func selectPersonality(_ code: String) -> Single<GenericResponse<String>> {
-        let body = SelectPersonalityRequest(personality: code)
-        return request(NetworkDefine.CharacterAPI.selectPersonality.url, method: .post, header: authHeader(), body: body)
-    }
 }

--- a/HaruUp/Network/Service/NetworkDefine.swift
+++ b/HaruUp/Network/Service/NetworkDefine.swift
@@ -32,6 +32,21 @@ enum NetworkDefine {
 
         var url: String { return APIEnvironment.baseURL + self.path }
     }
+
+    /// 캐릭터 성격 (큐레이션 꼬리질문 말투에 반영)
+    enum CharacterAPI {
+        case personalityList
+        case selectPersonality
+
+        var path: String {
+            switch self {
+            case .personalityList:   return "api/character/personality/list"
+            case .selectPersonality: return "api/character/personality"
+            }
+        }
+
+        var url: String { return APIEnvironment.baseURL + self.path }
+    }
     
     enum AuthAPI {
         case snsLogin

--- a/HaruUp/Network/Service/NetworkDefine.swift
+++ b/HaruUp/Network/Service/NetworkDefine.swift
@@ -35,11 +35,13 @@ enum NetworkDefine {
 
     /// 캐릭터 성격 (큐레이션 꼬리질문 말투에 반영)
     enum CharacterAPI {
+        case list
         case personalityList
         case selectPersonality
 
         var path: String {
             switch self {
+            case .list:              return "api/character/list"
             case .personalityList:   return "api/character/personality/list"
             case .selectPersonality: return "api/character/personality"
             }

--- a/HaruUp/Presentation/Curation/CharacterSelect/CharacterSelectComplete/CharcterSelectCompleteCoordinator.swift
+++ b/HaruUp/Presentation/Curation/CharacterSelect/CharacterSelectComplete/CharcterSelectCompleteCoordinator.swift
@@ -30,17 +30,19 @@ final class CharacterSelectCompleteCoordinator: Coordinator {
     }
     
     
+    /// 챗봇으로 바로 넘어가지 않고 AI 성격 선택을 먼저 거친다.
+    /// 성격 선택이 끝나면 그 코디네이터가 이어서 챗봇을 시작한다.
     func showCurationChatFlow(selectedCharacter: Int) {
         curationData.characterId = selectedCharacter
         print("📦 저장된 데이터 - 캐릭터: \(selectedCharacter)")
 
-        let curationChatCoordinator = CurationChatCoordinator(
+        let personalitySelectCoordinator = PersonalitySelectCoordinator(
             navigationController: navigationController,
             curationData: curationData
         )
 
-        curationChatCoordinator.onFinish = { [weak self, weak curationChatCoordinator] curationData in
-            if let coordinator = curationChatCoordinator,
+        personalitySelectCoordinator.onFinish = { [weak self, weak personalitySelectCoordinator] curationData in
+            if let coordinator = personalitySelectCoordinator,
                let index = self?.childCoordinators.firstIndex(where: { $0 === coordinator }) {
                 self?.childCoordinators.remove(at: index)
             }
@@ -48,8 +50,8 @@ final class CharacterSelectCompleteCoordinator: Coordinator {
             self?.onFinish?(curationData)
         }
 
-        childCoordinators.append(curationChatCoordinator)
-        curationChatCoordinator.start()
+        childCoordinators.append(personalitySelectCoordinator)
+        personalitySelectCoordinator.start()
     }
     
 }

--- a/HaruUp/Presentation/Curation/CharacterSelect/CharacterSelectViewController.swift
+++ b/HaruUp/Presentation/Curation/CharacterSelect/CharacterSelectViewController.swift
@@ -17,10 +17,20 @@ class CharacterSelectViewController: UIViewController {
     
     private let currentCharacterIndex = BehaviorRelay<Int>(value: 1)
     
+    /// 이미지는 앱에 번들된 에셋이라 앱이 들고 있고, 이름은 서버에서 받아 덮어쓴다.
+    /// 서버 이름을 못 받았을 때만 여기 적힌 이름을 그대로 쓴다.
     private let characters: [(name: String, image: String)] = [
         (name: "하루", image: "haru_level1"),
         (name: "나루", image: "naru_level1")
     ]
+
+    /// characterId → 서버가 내려준 이름
+    private var serverCharacterNames: [Int: String] = [:]
+
+    /// 화면에 표시할 캐릭터 이름. 서버 값이 있으면 그것을 쓴다.
+    private func displayName(at index: Int) -> String {
+        serverCharacterNames[index] ?? characters[index - 1].name
+    }
     
     private let backgroundImageView: UIImageView = {
         let iv = UIImageView()
@@ -259,7 +269,7 @@ class CharacterSelectViewController: UIViewController {
             self?.characterImageView.image = UIImage(named: character.image)
         }
         
-        characterNameLabel.text = character.name
+        characterNameLabel.text = displayName(at: index)
         
         // 화살표 버튼 활성화/비활성화
         leftArrowButton.isEnabled = index > 1
@@ -277,7 +287,7 @@ class CharacterSelectViewController: UIViewController {
             .subscribe(onNext: { [weak self] in
                 guard let self = self else { return }
                 let index = self.currentCharacterIndex.value
-                let characterName = index <= self.characters.count ? self.characters[index - 1].name : ""
+                let characterName = index <= self.characters.count ? self.displayName(at: index) : ""
                 AnalyticsManager.shared.track(event: AppEvent.CharacterSelect.nextTapped, properties: ["character": characterName])
             })
             .disposed(by: disposeBag)
@@ -291,6 +301,15 @@ class CharacterSelectViewController: UIViewController {
         output.isValid
             .drive(onNext: { [weak self] isValid in
                 self?.nextButton.isEnabled = isValid
+            })
+            .disposed(by: disposeBag)
+
+        // 서버에서 캐릭터 이름을 받으면 현재 표시 중인 캐릭터에 바로 반영한다
+        output.characterNames
+            .drive(onNext: { [weak self] names in
+                guard let self = self, !names.isEmpty else { return }
+                self.serverCharacterNames = names
+                self.characterNameLabel.text = self.displayName(at: self.currentCharacterIndex.value)
             })
             .disposed(by: disposeBag)
     }

--- a/HaruUp/Presentation/Curation/CharacterSelect/CharacterSelectViewModel.swift
+++ b/HaruUp/Presentation/Curation/CharacterSelect/CharacterSelectViewModel.swift
@@ -18,15 +18,41 @@ final class CharacterSelectViewModel {
     struct Output {
         let isValid: Driver<Bool>
         let selectedCharacter: Driver<Int?>
+        /// characterId → 이름. 서버에서 받아 화면에 표시한다.
+        let characterNames: Driver<[Int: String]>
     }
     
     private weak var coordinator: CharacterSelectCoordinator?
+    private let characterService: CharacterService
     private let disposeBag = DisposeBag()
     
     private let currentCharacter = BehaviorRelay<Int?>(value: nil)
+    private let characterNamesRelay = BehaviorRelay<[Int: String]>(value: [:])
     
-    init(coordinator: CharacterSelectCoordinator) {
+    init(coordinator: CharacterSelectCoordinator, characterService: CharacterService = CharacterService()) {
         self.coordinator = coordinator
+        self.characterService = characterService
+        loadCharacterNames()
+    }
+
+    /// 캐릭터 이름을 서버에서 받아온다.
+    /// 실패하면 relay 를 비워 둔 채로 두고, 화면이 앱에 있는 기본 이름을 그대로 쓴다.
+    /// 이름을 못 받았다고 캐릭터 선택 자체를 막을 이유는 없다.
+    private func loadCharacterNames() {
+        characterService.characterList()
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] characters in
+                    let names = characters.reduce(into: [Int: String]()) { dict, character in
+                        if let name = character.name, !name.isEmpty {
+                            dict[character.id] = name
+                        }
+                    }
+                    self?.characterNamesRelay.accept(names)
+                },
+                onFailure: { _ in }
+            )
+            .disposed(by: disposeBag)
     }
     
     
@@ -60,7 +86,9 @@ final class CharacterSelectViewModel {
             .asDriver()
         
         return Output(
-            isValid: isValid, selectedCharacter: selectedCharacter
+            isValid: isValid,
+            selectedCharacter: selectedCharacter,
+            characterNames: characterNamesRelay.asDriver()
         )
     }
 }

--- a/HaruUp/Presentation/Curation/CurationChat/Cells/BotMessageCell.swift
+++ b/HaruUp/Presentation/Curation/CurationChat/Cells/BotMessageCell.swift
@@ -113,7 +113,15 @@ final class BotMessageCell: UITableViewCell {
         shimmerTextView.stopShimmering()
     }
 
-    func configure(text: String, highlightedText: String? = nil, subtitleText: String? = nil, isShimmering: Bool = false) {
+    /// - Parameter isError: 목표를 하나만 입력해달라는 안내처럼 사용자가 고쳐야 하는 메시지.
+    ///   눈에 띄어야 하므로 강조 색으로 표시한다.
+    func configure(
+        text: String,
+        highlightedText: String? = nil,
+        subtitleText: String? = nil,
+        isShimmering: Bool = false,
+        isError: Bool = false
+    ) {
         if isShimmering {
             // bubbleView 높이 확보를 위해 messageLabel에도 텍스트 설정 (표시는 숨김)
             messageLabel.setStyle(Typography.body4, text: text)
@@ -134,13 +142,13 @@ final class BotMessageCell: UITableViewCell {
                     Typography.body4,
                     fullText: text,
                     highlightedText: highlighted,
-                    highlightedColor: .black,
+                    highlightedColor: isError ? .secondaryRed200 : .black,
                     defaultColor: .neutral800,
                     highlightedFont: Typography.body2.font
                 )
             } else {
                 messageLabel.setStyle(Typography.body4, text: text)
-                messageLabel.textColor = .black
+                messageLabel.textColor = isError ? .secondaryRed200 : .black
             }
         }
 

--- a/HaruUp/Presentation/Curation/CurationChat/CurationChatViewController.swift
+++ b/HaruUp/Presentation/Curation/CurationChat/CurationChatViewController.swift
@@ -39,7 +39,8 @@ final class CurationChatViewController: UIViewController {
         pv.progressTintColor = .cta
         pv.layer.cornerRadius = 2
         pv.clipsToBounds = true
-        pv.progress = 1.0 / Float(CurationChatViewModel.totalSteps)
+        // 실제 값은 ViewModel 이 내려준다. 첫 프레임에 0으로 보이지 않게만 잡아 둔다.
+        pv.progress = 0.15
         pv.translatesAutoresizingMaskIntoConstraints = false
         return pv
     }()
@@ -101,6 +102,20 @@ final class CurationChatViewController: UIViewController {
 
     private var inputContainerBottomConstraint: NSLayoutConstraint?
     private var inputTextViewHeightConstraint: NSLayoutConstraint?
+
+    /// 입력창 안내 문구. 서버가 첫 질문에 예시를 내려주면 그 값으로 바뀐다.
+    private var currentPlaceholder = "답변을 입력해주세요"
+
+    /// 입력창이 안내 문구를 보여주는 중인지 (사용자가 실제로 입력한 상태와 구분)
+    private var isShowingPlaceholder: Bool {
+        inputTextView.textColor == .neutral300
+    }
+
+    /// 입력창을 안내 문구 상태로 되돌린다.
+    private func resetInputToPlaceholder() {
+        inputTextView.text = currentPlaceholder
+        inputTextView.textColor = .neutral300
+    }
     
     // MARK: - Init
     init(viewModel: CurationChatViewModel) {
@@ -299,10 +314,22 @@ final class CurationChatViewController: UIViewController {
             .disposed(by: disposeBag)
 
         // 프로그레스바 업데이트
-        output.currentStep
-            .drive(onNext: { [weak self] step in
-                let progress = Float(step) / Float(CurationChatViewModel.totalSteps)
+        // 질문 개수가 대화마다 달라 ViewModel 이 비율을 직접 계산해 내려준다.
+        output.progress
+            .drive(onNext: { [weak self] progress in
                 self?.progressView.setProgress(progress, animated: true)
+            })
+            .disposed(by: disposeBag)
+
+        // 입력창 안내 문구 (서버가 첫 질문에 예시를 내려준다)
+        output.inputPlaceholder
+            .drive(onNext: { [weak self] placeholder in
+                guard let self = self else { return }
+                // 사용자가 이미 입력 중이면 건드리지 않는다
+                self.currentPlaceholder = placeholder
+                // 사용자가 이미 입력 중이면 건드리지 않는다
+                guard self.isShowingPlaceholder else { return }
+                self.resetInputToPlaceholder()
             })
             .disposed(by: disposeBag)
 
@@ -318,15 +345,14 @@ final class CurationChatViewController: UIViewController {
     private func sendMessage() {
         let text = inputTextView.text ?? ""
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              text != "답변을 입력해주세요" else {
+              text != currentPlaceholder else {
             return
         }
         
         sendButton.isEnabled = false
         
         sendSubject.onNext(text.trimmingCharacters(in: .whitespacesAndNewlines))
-        inputTextView.text = "답변을 입력해주세요"
-        inputTextView.textColor = .neutral300
+        resetInputToPlaceholder()
         
         sendButton.setImage(.iconButtonGray, for: .normal)
         inputTextView.resignFirstResponder()
@@ -343,8 +369,7 @@ final class CurationChatViewController: UIViewController {
         modalVC.modalTransitionStyle = .crossDissolve
         modalVC.onRestartTapped = { [weak self] in
             self?.viewModel.restartChat()
-            self?.inputTextView.text = "답변을 입력해주세요"
-            self?.inputTextView.textColor = .neutral300
+            self?.resetInputToPlaceholder()
             self?.sendButton.setImage(.iconButtonGray, for: .normal)
             self?.view.endEditing(true)
         }
@@ -437,7 +462,8 @@ extension CurationChatViewController: UITableViewDataSource {
                 text: message.text,
                 highlightedText: message.highlightedText,
                 subtitleText: message.subtitleText,
-                isShimmering: message.isShimmering
+                isShimmering: message.isShimmering,
+                isError: message.isError
             )
             return cell
 
@@ -476,7 +502,7 @@ extension CurationChatViewController: UITextViewDelegate {
 
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            textView.text = "답변을 입력해주세요"
+            textView.text = currentPlaceholder
             textView.textColor = .neutral300
             sendButton.setImage(.iconButtonGray, for: .normal)
         }

--- a/HaruUp/Presentation/Curation/CurationChat/CurationChatViewModel.swift
+++ b/HaruUp/Presentation/Curation/CurationChat/CurationChatViewModel.swift
@@ -25,6 +25,8 @@ struct ChatMessage {
     let suggestions: [String]
     let subtitleText: String?
     let isShimmering: Bool
+    /// 사용자가 고쳐서 다시 입력해야 하는 안내인지 (목표를 하나만 입력해달라는 경우 등)
+    let isError: Bool
 
     init(
         type: ChatMessageType,
@@ -32,7 +34,8 @@ struct ChatMessage {
         highlightedText: String? = nil,
         suggestions: [String] = [],
         subtitleText: String? = nil,
-        isShimmering: Bool = false
+        isShimmering: Bool = false,
+        isError: Bool = false
     ) {
         self.id = UUID()
         self.type = type
@@ -41,6 +44,7 @@ struct ChatMessage {
         self.suggestions = suggestions
         self.subtitleText = subtitleText
         self.isShimmering = isShimmering
+        self.isError = isError
     }
 }
 
@@ -70,10 +74,19 @@ final class CurationChatViewModel {
         let characterName: Driver<String>
         let characterImageName: Driver<String>
         let prefillText: Driver<String>
-        let currentStep: Driver<Int>
+        /// 0.0 ~ 1.0. 질문 개수가 대화마다 달라져 단계 수로는 표현할 수 없다.
+        let progress: Driver<Float>
+        /// 입력창에 표시할 안내 문구 (서버가 첫 질문에 내려준다)
+        let inputPlaceholder: Driver<String>
     }
 
-    static let totalSteps = 7
+    /// 진행률 계산에 쓰는 기준 단계 수 (닉네임 1 + 목표 1 + 꼬리질문 5).
+    /// 서버가 꼬리질문을 3~8개 사이에서 조절하므로 실제 총 개수는 대화가 끝나야 알 수 있다.
+    /// 그래서 이 값은 어디까지나 기준이고, 대화가 길어지면 분모를 늘려 진행률이 역행하지 않게 한다.
+    private static let baselineTotalSteps = 7
+
+    /// 완료 전에는 진행률을 이 값 이상으로 올리지 않는다. 다 찼는데 질문이 더 나오는 상황을 막는다.
+    private static let maxProgressBeforeComplete: Float = 0.95
 
     private weak var coordinator: CurationChatCoordinator?
     private let disposeBag = DisposeBag()
@@ -87,13 +100,18 @@ final class CurationChatViewModel {
     private var sessionId: String?
     private var completedMissions: [ChatbotMissionDto] = []
     private let isLoadingRelay = BehaviorRelay<Bool>(value: false)
-    private let currentStepRelay = BehaviorRelay<Int>(value: 1)
+    private let progressRelay = BehaviorRelay<Float>(value: 1.0 / Float(baselineTotalSteps))
+    private let inputPlaceholderRelay = BehaviorRelay<String>(value: "답변을 입력해주세요")
 
     // MARK: - Chat Phase
     private enum ChatPhase { case nickname, chatbot }
     private var currentPhase: ChatPhase = .nickname
     private var collectedNickname: String = ""
     private var isLastQuestion: Bool = false
+
+    /// 마무리 확인("이대로 마무리할까요?")을 띄워 두고 사용자의 예/아니오를 기다리는 중인지.
+    /// 이 상태에서 보낸 답변은 꼬리질문 답변이 아니라 마무리 여부 선택이다.
+    private var awaitingFinishConfirmation: Bool = false
 
     init(coordinator: CurationChatCoordinator, characterId: Int, chatbotService: ChatbotService) {
         self.coordinator = coordinator
@@ -175,7 +193,8 @@ final class CurationChatViewModel {
             characterName: Driver.just(characterName),
             characterImageName: Driver.just(characterImageName),
             prefillText: prefillTextRelay.asDriver(onErrorJustReturn: ""),
-            currentStep: currentStepRelay.asDriver()
+            progress: progressRelay.asDriver(),
+            inputPlaceholder: inputPlaceholderRelay.asDriver()
         )
     }
     
@@ -188,8 +207,35 @@ final class CurationChatViewModel {
         currentPhase = .nickname
         collectedNickname = ""
         isLastQuestion = false
-        currentStepRelay.accept(1)
+        awaitingFinishConfirmation = false
+        progressRelay.accept(1.0 / Float(Self.baselineTotalSteps))
+        inputPlaceholderRelay.accept("답변을 입력해주세요")
         showNicknameQuestion()
+    }
+
+    /// 마무리 확인 답변이 긍정인지 판단한다.
+    ///
+    /// 판정 자체는 서버가 하고, 앱은 "미션 생성 중" 표시를 미리 띄울지 정하는 데만 쓴다.
+    /// 그래서 틀려도 화면 연출만 달라지고 대화 흐름에는 영향이 없다.
+    /// 부정을 먼저 걸러야 "아니요, 미션 만들어주세요" 같은 답을 긍정으로 잘못 읽지 않는다.
+    private func isAffirmative(_ answer: String) -> Bool {
+        let negatives = ["아니", "아뇨", "싫", "더 ", "계속", "나중"]
+        if negatives.contains(where: { answer.contains($0) }) { return false }
+
+        let affirmatives = ["네", "예", "응", "좋", "만들", "마무리", "끝", "그만", "충분", "시작"]
+        return affirmatives.contains(where: { answer.contains($0) })
+    }
+
+    /// 대화 단계에 맞춰 진행률을 갱신한다.
+    ///
+    /// 꼬리질문 개수가 대화마다 달라 총 단계 수를 미리 알 수 없다.
+    /// 그래서 기준값을 쓰되, 대화가 그보다 길어지면 분모를 함께 늘려
+    /// 진행률이 뒤로 가거나 100%에 먼저 도달하는 일이 없게 한다.
+    private func updateProgress(questionNumber: Int) {
+        let currentStep = questionNumber + 1                    // 닉네임 단계를 한 칸으로 친다
+        let total = max(currentStep + 1, Self.baselineTotalSteps)
+        let ratio = Float(currentStep) / Float(total)
+        progressRelay.accept(min(ratio, Self.maxProgressBeforeComplete))
     }
 
     // MARK: - Private
@@ -204,8 +250,9 @@ final class CurationChatViewModel {
             guard let sessionId = sessionId else { return }
             appendMessage(ChatMessage(type: .user, text: trimmed))
 
-            // 마지막 질문의 답변인 경우 미션 생성 중 메시지를 먼저 표시
-            if isLastQuestion {
+            // 미션 생성으로 이어지는 답변이면 생성 중 메시지를 먼저 표시한다.
+            // 마지막 질문의 답변이거나, 마무리 확인에 "예"라고 답한 경우다.
+            if isLastQuestion || (awaitingFinishConfirmation && isAffirmative(trimmed)) {
                 appendMessage(ChatMessage(
                     type: .bot,
                     text: "\(collectedNickname)님을 위한 맞춤 미션을 만드는 중이에요!",
@@ -358,9 +405,14 @@ final class CurationChatViewModel {
                     guard let self = self, let data = response.data else { return }
                     self.isLoadingRelay.accept(false)
                     self.sessionId = data.sessionId
-                    self.currentStepRelay.accept(data.questionNumber + 1)
+                    self.updateProgress(questionNumber: data.questionNumber)
 
-                    // 첫 질문 + 예시 칩 표시
+                    // 첫 질문에는 선택지가 없다. 사용자가 예시를 그대로 고르면
+                    // 목표가 구체화되지 않아 서버가 placeholder 로만 예시를 내려준다.
+                    if let placeholder = data.placeholder, !placeholder.isEmpty {
+                        self.inputPlaceholderRelay.accept(placeholder)
+                    }
+
                     self.appendMessage(ChatMessage(
                         type: .bot,
                         text: data.question,
@@ -377,26 +429,80 @@ final class CurationChatViewModel {
     
     private func handleAnswerResponse(_ data: ChatbotAnswerResultData?) {
         guard let data = data else { return }
-        
-        if data.isCompleted == true {
-            // 완료 → 미션 저장 후 화면 전환
-            completedMissions = data.missions ?? []
-            appendMessage(ChatMessage(type: .bot, text: "좋아요! 답변을 바탕으로 맞춤 미션을 준비했어요!!!🎉"))
-            isCompletedRelay.accept(true)
-        }
-        else {
-            // 진행 중 → 다음 질문 표시
-            guard let question = data.question else { return }
-            let isLast = data.isLast ?? false
-            isLastQuestion = isLast
 
-            if let questionNumber = data.questionNumber {
-                currentStepRelay.accept(questionNumber + 1)
-            }
-
-            appendMessage(ChatMessage(type: .bot, text: question,
-                                      subtitleText: isLast ? "마지막 질문이에요!" : nil))
+        switch data.kind {
+        case .completed:
+            handleCompleted(data)
+        case .goalRejected:
+            handleGoalRejected(data)
+        case .finishConfirm:
+            handleFinishConfirm(data)
+        case .nextQuestion:
+            handleNextQuestion(data)
+        case .unknown:
+            // 앱이 모르는 응답이 와도 대화가 멈춘 것처럼 보이지 않게 안내한다.
+            appendMessage(ChatMessage(type: .bot, text: "예상하지 못한 응답을 받았어요. 다시 시도해주세요."))
         }
+    }
+
+    /// 대화 종료 — 미션 생성 완료
+    private func handleCompleted(_ data: ChatbotAnswerResultData) {
+        awaitingFinishConfirmation = false
+        completedMissions = data.missions ?? []
+        progressRelay.accept(1.0)
+        appendMessage(ChatMessage(type: .bot, text: "좋아요! 답변을 바탕으로 맞춤 미션을 준비했어요!!!🎉"))
+        isCompletedRelay.accept(true)
+    }
+
+    /// 목표를 2개 이상 입력한 경우 — 질문을 진행하지 않고 다시 입력받는다.
+    /// 세션은 그대로라 같은 sessionId 로 목표만 다시 보내면 된다.
+    private func handleGoalRejected(_ data: ChatbotAnswerResultData) {
+        let message = data.message ?? "목표를 하나만 입력해주세요!"
+        let detected = data.detectedGoals ?? []
+        let subtitle = detected.isEmpty ? nil : "입력하신 목표: \(detected.joined(separator: ", "))"
+
+        appendMessage(ChatMessage(
+            type: .bot,
+            text: message,
+            highlightedText: message,
+            subtitleText: subtitle,
+            isError: true
+        ))
+    }
+
+    /// 정보가 충분히 모였을 때 — 요약을 보여주고 마무리할지 묻는다.
+    private func handleFinishConfirm(_ data: ChatbotAnswerResultData) {
+        awaitingFinishConfirmation = true
+        isLastQuestion = false
+
+        if let summary = data.summary, !summary.isEmpty {
+            appendMessage(ChatMessage(type: .bot, text: summary))
+        }
+
+        appendMessage(ChatMessage(
+            type: .bot,
+            text: data.question ?? "이대로 마무리할까요?",
+            suggestions: data.examples ?? []
+        ))
+    }
+
+    /// 다음 질문 표시 (AI 꼬리질문 또는 투자 가능 시간 고정 질문)
+    private func handleNextQuestion(_ data: ChatbotAnswerResultData) {
+        guard let question = data.question else { return }
+
+        awaitingFinishConfirmation = false
+        isLastQuestion = data.isLast ?? false
+
+        if let questionNumber = data.questionNumber {
+            updateProgress(questionNumber: questionNumber)
+        }
+
+        appendMessage(ChatMessage(
+            type: .bot,
+            text: question,
+            suggestions: data.examples ?? [],
+            subtitleText: isLastQuestion ? "마지막 질문이에요!" : nil
+        ))
     }
     
     

--- a/HaruUp/Presentation/Curation/CurationChat/CurationChatViewModel.swift
+++ b/HaruUp/Presentation/Curation/CurationChat/CurationChatViewModel.swift
@@ -71,7 +71,6 @@ final class CurationChatViewModel {
         let displayItems: Driver<[ChatDisplayItem]>
         let isCompleted: Driver<Bool>
         let isLoading: Driver<Bool>
-        let characterName: Driver<String>
         let characterImageName: Driver<String>
         let prefillText: Driver<String>
         /// 0.0 ~ 1.0. 질문 개수가 대화마다 달라져 단계 수로는 표현할 수 없다.
@@ -120,19 +119,12 @@ final class CurationChatViewModel {
     }
 
     func transform(input: Input) -> Output {
-        let characterName: String
+        // 이미지는 앱에 번들된 에셋이라 characterId 로 고른다.
+        // 캐릭터 이름은 서버가 첫 질문 문구에 넣어 보내주므로 앱이 따로 들고 있지 않는다.
         let characterImageName: String
-
         switch characterId {
-        case 1:
-            characterName = "하루"
-            characterImageName = "character_haru_profile"
-        case 2:
-            characterName = "나루"
-            characterImageName = "character_naru_profile"
-        default:
-            characterName = "하루"
-            characterImageName = "character_haru_profile"
+        case 2:  characterImageName = "character_naru_profile"
+        default: characterImageName = "character_haru_profile"
         }
 
         // 화면 표시 시 닉네임 질문 먼저 표시
@@ -190,7 +182,6 @@ final class CurationChatViewModel {
             displayItems: displayItems,
             isCompleted: isCompletedRelay.asDriver(),
             isLoading: isLoadingRelay.asDriver(),
-            characterName: Driver.just(characterName),
             characterImageName: Driver.just(characterImageName),
             prefillText: prefillTextRelay.asDriver(onErrorJustReturn: ""),
             progress: progressRelay.asDriver(),

--- a/HaruUp/Presentation/Curation/CurationChat/CurationChatViewModel.swift
+++ b/HaruUp/Presentation/Curation/CurationChat/CurationChatViewModel.swift
@@ -250,8 +250,9 @@ final class CurationChatViewModel {
             guard let sessionId = sessionId else { return }
             appendMessage(ChatMessage(type: .user, text: trimmed))
 
-            // 미션 생성으로 이어지는 답변이면 생성 중 메시지를 먼저 표시한다.
-            // 마지막 질문의 답변이거나, 마무리 확인에 "예"라고 답한 경우다.
+            // 미션 생성으로 이어질 답변이면 생성 중 메시지를 먼저 표시한다.
+            // 마무리를 골라도 시간 투자가 필요한 목표면 질문이 한 번 더 오므로,
+            // 완료가 아닌 응답이 오면 이 메시지를 지운다. (removePendingShimmer)
             if isLastQuestion || (awaitingFinishConfirmation && isAffirmative(trimmed)) {
                 appendMessage(ChatMessage(
                     type: .bot,
@@ -457,6 +458,7 @@ final class CurationChatViewModel {
     /// 목표를 2개 이상 입력한 경우 — 질문을 진행하지 않고 다시 입력받는다.
     /// 세션은 그대로라 같은 sessionId 로 목표만 다시 보내면 된다.
     private func handleGoalRejected(_ data: ChatbotAnswerResultData) {
+        removePendingShimmer()
         let message = data.message ?? "목표를 하나만 입력해주세요!"
         let detected = data.detectedGoals ?? []
         let subtitle = detected.isEmpty ? nil : "입력하신 목표: \(detected.joined(separator: ", "))"
@@ -472,6 +474,7 @@ final class CurationChatViewModel {
 
     /// 정보가 충분히 모였을 때 — 요약을 보여주고 마무리할지 묻는다.
     private func handleFinishConfirm(_ data: ChatbotAnswerResultData) {
+        removePendingShimmer()
         awaitingFinishConfirmation = true
         isLastQuestion = false
 
@@ -488,6 +491,7 @@ final class CurationChatViewModel {
 
     /// 다음 질문 표시 (AI 꼬리질문 또는 투자 가능 시간 고정 질문)
     private func handleNextQuestion(_ data: ChatbotAnswerResultData) {
+        removePendingShimmer()
         guard let question = data.question else { return }
 
         awaitingFinishConfirmation = false
@@ -506,6 +510,17 @@ final class CurationChatViewModel {
     }
     
     
+    /// 미션 생성 중 메시지를 걷어낸다.
+    ///
+    /// 마무리를 골라도 시간 투자가 필요한 목표면 질문이 한 번 더 온다.
+    /// 그때 "만드는 중" 문구가 남아 있으면 사용자가 끝난 줄 알았다가 질문을 다시 받게 된다.
+    private func removePendingShimmer() {
+        var msgs = messagesRelay.value
+        guard msgs.last?.isShimmering == true else { return }
+        msgs.removeLast()
+        messagesRelay.accept(msgs)
+    }
+
     private func appendMessage(_ message: ChatMessage) {
         var msgs = messagesRelay.value
         msgs.append(message)

--- a/HaruUp/Presentation/Curation/PersonalitySelect/PersonalitySelectCoordinator.swift
+++ b/HaruUp/Presentation/Curation/PersonalitySelect/PersonalitySelectCoordinator.swift
@@ -21,7 +21,7 @@ final class PersonalitySelectCoordinator: Coordinator {
     }
 
     func start() {
-        let viewModel = PersonalitySelectViewModel(coordinator: self, chatbotService: ChatbotService())
+        let viewModel = PersonalitySelectViewModel(coordinator: self, characterService: CharacterService())
         let viewController = PersonalitySelectViewController(viewModel: viewModel)
 
         navigationController.pushViewController(viewController, animated: true)

--- a/HaruUp/Presentation/Curation/PersonalitySelect/PersonalitySelectCoordinator.swift
+++ b/HaruUp/Presentation/Curation/PersonalitySelect/PersonalitySelectCoordinator.swift
@@ -1,0 +1,52 @@
+//
+//  PersonalitySelectCoordinator.swift
+//  HaruUp
+//
+
+import UIKit
+
+/// 캐릭터 인사 이후, 챗봇 시작 전에 AI 성격을 고르는 단계.
+/// 여기서 고른 성격은 큐레이션 꼬리질문의 말투에만 반영된다.
+final class PersonalitySelectCoordinator: Coordinator {
+    let navigationController: UINavigationController
+
+    var childCoordinators: [any Coordinator] = []
+
+    private var curationData: CurationData
+    var onFinish: ((CurationData) -> Void)?
+
+    init(navigationController: UINavigationController, curationData: CurationData) {
+        self.navigationController = navigationController
+        self.curationData = curationData
+    }
+
+    func start() {
+        let viewModel = PersonalitySelectViewModel(coordinator: self, chatbotService: ChatbotService())
+        let viewController = PersonalitySelectViewController(viewModel: viewModel)
+
+        navigationController.pushViewController(viewController, animated: true)
+    }
+
+    func didSelectPersonality() {
+        showCurationChatFlow()
+    }
+
+    private func showCurationChatFlow() {
+        let curationChatCoordinator = CurationChatCoordinator(
+            navigationController: navigationController,
+            curationData: curationData
+        )
+
+        curationChatCoordinator.onFinish = { [weak self, weak curationChatCoordinator] curationData in
+            if let coordinator = curationChatCoordinator,
+               let index = self?.childCoordinators.firstIndex(where: { $0 === coordinator }) {
+                self?.childCoordinators.remove(at: index)
+            }
+
+            self?.onFinish?(curationData)
+        }
+
+        childCoordinators.append(curationChatCoordinator)
+        curationChatCoordinator.start()
+    }
+}

--- a/HaruUp/Presentation/Curation/PersonalitySelect/PersonalitySelectViewController.swift
+++ b/HaruUp/Presentation/Curation/PersonalitySelect/PersonalitySelectViewController.swift
@@ -1,0 +1,215 @@
+//
+//  PersonalitySelectViewController.swift
+//  HaruUp
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+
+/// 캐릭터 인사 이후, 챗봇 시작 전에 AI 성격을 고르는 화면.
+/// 여기서 고른 성격은 큐레이션 꼬리질문의 말투에만 반영된다.
+final class PersonalitySelectViewController: UIViewController {
+
+    // MARK: - Properties
+    private let viewModel: PersonalitySelectViewModel
+    private let disposeBag = DisposeBag()
+
+    private let viewDidLoadSubject = PublishSubject<Void>()
+    private let selectionSubject = PublishSubject<Int>()
+
+    /// 선택지는 서버에서 받아 그릴 때 만든다
+    private var optionButtons: [SelectButton] = []
+
+    private let backgroundImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.image = UIImage(named: "background_gradation.png")
+        iv.contentMode = .scaleAspectFill
+        return iv
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        let style = FontStyle(font: Typography.title2.font, lineHeight: 1.38)
+        label.setStyle(style, text: "어떤 방식으로\n도와드릴까요?")
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.textColor = .black
+        return label
+    }()
+
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.setStyle(Typography.body1, text: "선택한 성격에 맞춰 질문을 드려요.")
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.textColor = .neutral600
+        return label
+    }()
+
+    private let optionStackView: UIStackView = {
+        let sv = UIStackView()
+        sv.axis = .vertical
+        sv.spacing = 12
+        sv.distribution = .fillEqually
+        return sv
+    }()
+
+    private let nextButton: UIButton = {
+        let btn = UIButton()
+        btn.setTitle("다음", for: .normal)
+        btn.titleLabel?.font = Typography.subtitle2.font
+        btn.backgroundColor = .cta
+        btn.layer.cornerRadius = 16
+        btn.clipsToBounds = true
+        return btn
+    }()
+
+    private let loadingIndicator: UIActivityIndicatorView = {
+        let iv = UIActivityIndicatorView(style: .medium)
+        iv.hidesWhenStopped = true
+        return iv
+    }()
+
+    // MARK: - Init
+    init(viewModel: PersonalitySelectViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupUI()
+        bindViewModel()
+        viewDidLoadSubject.onNext(())
+    }
+
+    // MARK: - Helpers
+    private func setupUI() {
+        view.insertSubview(backgroundImageView, at: 0)
+
+        [titleLabel, subtitleLabel, optionStackView, nextButton, loadingIndicator].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview($0)
+        }
+
+        backgroundImageView.anchor(
+            top: view.topAnchor,
+            left: view.leftAnchor,
+            bottom: view.bottomAnchor,
+            right: view.rightAnchor
+        )
+
+        titleLabel.anchor(
+            top: view.safeAreaLayoutGuide.topAnchor,
+            left: view.leftAnchor,
+            right: view.rightAnchor,
+            paddingTop: 100,
+            paddingLeft: 20,
+            paddingRight: 20
+        )
+
+        subtitleLabel.anchor(
+            top: titleLabel.bottomAnchor,
+            left: view.leftAnchor,
+            right: view.rightAnchor,
+            paddingTop: 12,
+            paddingLeft: 20,
+            paddingRight: 20
+        )
+
+        optionStackView.anchor(
+            top: subtitleLabel.bottomAnchor,
+            left: view.leftAnchor,
+            right: view.rightAnchor,
+            paddingTop: 48,
+            paddingLeft: 20,
+            paddingRight: 20
+        )
+
+        loadingIndicator.centerX(inView: view)
+        loadingIndicator.anchor(top: optionStackView.bottomAnchor, paddingTop: 24)
+
+        nextButton.anchor(
+            left: view.leftAnchor,
+            bottom: view.safeAreaLayoutGuide.bottomAnchor,
+            right: view.rightAnchor,
+            paddingLeft: 20,
+            paddingBottom: 10,
+            paddingRight: 20,
+            height: 56
+        )
+    }
+
+    private func bindViewModel() {
+        let input = PersonalitySelectViewModel.Input(
+            viewDidLoad: viewDidLoadSubject.asObservable(),
+            personalitySelected: selectionSubject.asObservable(),
+            nextButtonTapped: nextButton.rx.tap.asObservable()
+        )
+
+        let output = viewModel.transform(input: input)
+
+        output.personalities
+            .drive(onNext: { [weak self] personalities in
+                self?.renderOptions(personalities)
+            })
+            .disposed(by: disposeBag)
+
+        output.selectedIndex
+            .drive(onNext: { [weak self] selected in
+                guard let self = self else { return }
+                for (index, button) in self.optionButtons.enumerated() {
+                    button.setSelected(index == selected)
+                }
+            })
+            .disposed(by: disposeBag)
+
+        output.isNextEnabled
+            .drive(onNext: { [weak self] enabled in
+                self?.nextButton.isEnabled = enabled
+                self?.nextButton.alpha = enabled ? 1.0 : 0.4
+            })
+            .disposed(by: disposeBag)
+
+        output.isLoading
+            .drive(onNext: { [weak self] isLoading in
+                if isLoading {
+                    self?.loadingIndicator.startAnimating()
+                } else {
+                    self?.loadingIndicator.stopAnimating()
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+
+    /// 서버에서 받은 선택지로 버튼을 다시 만든다.
+    private func renderOptions(_ personalities: [PersonalityData]) {
+        optionStackView.arrangedSubviews.forEach {
+            optionStackView.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+        optionButtons.removeAll()
+
+        for (index, personality) in personalities.enumerated() {
+            let button = SelectButton()
+            button.setTitle(personality.label, for: .normal)
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.heightAnchor.constraint(equalToConstant: 64).isActive = true
+
+            button.rx.tap
+                .map { index }
+                .bind(to: selectionSubject)
+                .disposed(by: disposeBag)
+
+            optionStackView.addArrangedSubview(button)
+            optionButtons.append(button)
+        }
+    }
+}

--- a/HaruUp/Presentation/Curation/PersonalitySelect/PersonalitySelectViewModel.swift
+++ b/HaruUp/Presentation/Curation/PersonalitySelect/PersonalitySelectViewModel.swift
@@ -1,0 +1,122 @@
+//
+//  PersonalitySelectViewModel.swift
+//  HaruUp
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+final class PersonalitySelectViewModel {
+
+    struct Input {
+        let viewDidLoad: Observable<Void>
+        let personalitySelected: Observable<Int>      // 목록에서 고른 인덱스
+        let nextButtonTapped: Observable<Void>
+    }
+
+    struct Output {
+        let personalities: Driver<[PersonalityData]>
+        let selectedIndex: Driver<Int?>
+        let isNextEnabled: Driver<Bool>
+        let isLoading: Driver<Bool>
+    }
+
+    /// 서버 목록을 못 받았을 때 쓰는 기본 선택지.
+    /// 성격을 못 고르면 큐레이션 자체를 진행할 수 없으므로 화면을 비워 두지 않는다.
+    /// 서버가 고르지 않은 회원에게 적용하는 기본값과 같은 순서로 둔다.
+    static let fallbackPersonalities: [PersonalityData] = [
+        PersonalityData(code: "WARM_FRIEND", label: "따뜻하게 응원하며 함께 가는 친구"),
+        PersonalityData(code: "CLEAR_COACH", label: "명확한 계획으로 이끌어주는 코치")
+    ]
+
+    private weak var coordinator: PersonalitySelectCoordinator?
+    private let chatbotService: ChatbotService
+    private let disposeBag = DisposeBag()
+
+    private let personalitiesRelay = BehaviorRelay<[PersonalityData]>(value: [])
+    private let selectedIndexRelay = BehaviorRelay<Int?>(value: nil)
+    private let isLoadingRelay = BehaviorRelay<Bool>(value: false)
+
+    init(coordinator: PersonalitySelectCoordinator, chatbotService: ChatbotService) {
+        self.coordinator = coordinator
+        self.chatbotService = chatbotService
+    }
+
+    func transform(input: Input) -> Output {
+        input.viewDidLoad
+            .take(1)
+            .subscribe(onNext: { [weak self] in
+                self?.loadPersonalities()
+            })
+            .disposed(by: disposeBag)
+
+        input.personalitySelected
+            .subscribe(onNext: { [weak self] index in
+                self?.selectedIndexRelay.accept(index)
+            })
+            .disposed(by: disposeBag)
+
+        input.nextButtonTapped
+            .subscribe(onNext: { [weak self] in
+                self?.submitSelection()
+            })
+            .disposed(by: disposeBag)
+
+        return Output(
+            personalities: personalitiesRelay.asDriver(),
+            selectedIndex: selectedIndexRelay.asDriver(),
+            isNextEnabled: selectedIndexRelay.map { $0 != nil }.asDriver(onErrorJustReturn: false),
+            isLoading: isLoadingRelay.asDriver()
+        )
+    }
+
+    // MARK: - Private
+
+    private func loadPersonalities() {
+        isLoadingRelay.accept(true)
+
+        chatbotService.personalityList()
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] response in
+                    guard let self = self else { return }
+                    self.isLoadingRelay.accept(false)
+
+                    let list = response.data ?? []
+                    self.personalitiesRelay.accept(list.isEmpty ? Self.fallbackPersonalities : list)
+                },
+                onFailure: { [weak self] _ in
+                    // 목록을 못 받아도 선택은 할 수 있어야 한다
+                    self?.isLoadingRelay.accept(false)
+                    self?.personalitiesRelay.accept(Self.fallbackPersonalities)
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    private func submitSelection() {
+        guard let index = selectedIndexRelay.value else { return }
+        let personalities = personalitiesRelay.value
+        guard index < personalities.count else { return }
+
+        let code = personalities[index].code
+        isLoadingRelay.accept(true)
+
+        chatbotService.selectPersonality(code)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] _ in
+                    self?.isLoadingRelay.accept(false)
+                    self?.coordinator?.didSelectPersonality()
+                },
+                onFailure: { [weak self] _ in
+                    // 저장에 실패해도 큐레이션은 진행한다.
+                    // 서버가 성격 미선택 회원에게 기본값을 적용하므로 대화가 막히지는 않는다.
+                    self?.isLoadingRelay.accept(false)
+                    self?.coordinator?.didSelectPersonality()
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+}

--- a/HaruUp/Presentation/Curation/PersonalitySelect/PersonalitySelectViewModel.swift
+++ b/HaruUp/Presentation/Curation/PersonalitySelect/PersonalitySelectViewModel.swift
@@ -31,16 +31,16 @@ final class PersonalitySelectViewModel {
     ]
 
     private weak var coordinator: PersonalitySelectCoordinator?
-    private let chatbotService: ChatbotService
+    private let characterService: CharacterService
     private let disposeBag = DisposeBag()
 
     private let personalitiesRelay = BehaviorRelay<[PersonalityData]>(value: [])
     private let selectedIndexRelay = BehaviorRelay<Int?>(value: nil)
     private let isLoadingRelay = BehaviorRelay<Bool>(value: false)
 
-    init(coordinator: PersonalitySelectCoordinator, chatbotService: ChatbotService) {
+    init(coordinator: PersonalitySelectCoordinator, characterService: CharacterService) {
         self.coordinator = coordinator
-        self.chatbotService = chatbotService
+        self.characterService = characterService
     }
 
     func transform(input: Input) -> Output {
@@ -76,7 +76,7 @@ final class PersonalitySelectViewModel {
     private func loadPersonalities() {
         isLoadingRelay.accept(true)
 
-        chatbotService.personalityList()
+        characterService.personalityList()
             .observe(on: MainScheduler.instance)
             .subscribe(
                 onSuccess: { [weak self] response in
@@ -103,7 +103,7 @@ final class PersonalitySelectViewModel {
         let code = personalities[index].code
         isLoadingRelay.accept(true)
 
-        chatbotService.selectPersonality(code)
+        characterService.selectPersonality(code)
             .observe(on: MainScheduler.instance)
             .subscribe(
                 onSuccess: { [weak self] _ in


### PR DESCRIPTION
백엔드 큐레이션 개편(백엔드 PR #14~#19)에 프론트가 따라가지 못해, **그대로 배포하면 챗봇 화면이 깨지는 상태**였습니다. 이를 맞추고 AI 성격 선택 화면을 추가합니다.

## 지금 깨져 있던 것

| 문제 | 원인 |
| --- | --- |
| 신규 응답 3종에서 화면이 멈춤 | `handleAnswerResponse` 가 `isCompleted` 로만 분기해, `question` 이 없는 응답은 `guard` 에서 조용히 빠져나감 |
| 꼬리질문 예시 답변이 안 보임 | `ChatbotAnswerResultData` 에 `examples` 필드 자체가 없었음. 서버가 내려주던 예시 답변 3개가 **한 번도 표시된 적 없음** |
| 첫 화면이 빈 상태 | 서버가 `examples` 를 빈 배열로 바꾸고 `placeholder` 로 예시를 내려주는데 모델에 그 필드가 없었음 |
| 진행률이 어긋남 | `totalSteps = 7` 하드코딩. 질문 수가 3~8개로 가변이 되어 `questionNumber` 가 최대 9까지 감 |

## 변경 내용

### 응답 모델
`ChatbotAnswerResultData` 에 `examples`, `questionType`, 목표 검증 실패, 마무리 확인, `summary` 필드를 추가하고 **`kind` 로 응답 종류를 판별**하도록 했습니다. 어디서도 쓰지 않던 `ChatbotNextQuestionData`, `ChatbotCompleteData` 는 제거했습니다.

`questionType` 은 서버가 새 값을 추가해도 앱이 죽지 않도록 `unknown` 으로 흡수합니다.

### 신규 응답 3종 처리

- **목표 검증 실패** — 목표를 2개 이상 입력하면 안내를 강조 색(`secondaryRed200`)으로 표시하고, 감지된 목표를 함께 보여줍니다. 세션이 유지되므로 같은 대화에서 목표만 다시 입력하면 됩니다
- **마무리 확인** — 요약을 보여주고 "이대로 마무리할까요?" 와 예/아니오 선택지를 제시합니다
- **투자 가능 시간 고정 질문** — 다른 질문과 같은 경로로 선택지를 표시합니다

### 진행률

질문 개수가 대화마다 달라 고정 단계 수로는 표현할 수 없어, ViewModel 이 비율(0.0~1.0)을 계산해 내려주도록 바꿨습니다. 대화가 기준(7단계)보다 길어지면 분모를 함께 늘려 **진행률이 뒤로 가거나 완료 전에 100% 가 되지 않게** 했습니다.

### 입력창 안내 문구

5곳에 하드코딩돼 있던 `"답변을 입력해주세요"` 를 서버가 내려주는 `placeholder` 로 대체했습니다. 사용자가 입력 중일 때는 덮어쓰지 않습니다.

### AI 성격 선택 화면 (신규)

```
캐릭터 선택 → 캐릭터 인사 → [신규] 성격 선택 → 챗봇 시작
```

- `따뜻하게 응원하며 함께 가는 친구` / `명확한 계획으로 이끌어주는 코치`
- 선택지는 서버에서 받아 그리며, **목록 조회나 저장이 실패해도 큐레이션은 그대로 진행**합니다. 서버가 미선택 회원에게 기본값(`WARM_FRIEND`)을 적용하므로 대화가 막히지 않습니다
- 기존 `SelectButton` 컴포넌트를 재사용했습니다

## 검증

**iPhone 16 Pro 시뮬레이터 대상 빌드 성공** (`BUILD SUCCEEDED`).

빌드 과정에서 `totalSteps` 제거 후 남아 있던 참조를 하나 잡아 수정했습니다.

## 리뷰어 참고

- **실제 서버와 연결해 화면을 확인하지는 못했습니다.** 빌드만 통과한 상태라, 목표 2개 입력 → 재입력 안내, 마무리 확인 → 예/아니오, 시간 질문 선택지가 실제로 잘 그려지는지는 QA 가 필요합니다
- **백엔드가 먼저 배포되어야 합니다.** 이 PR 만 배포하면 서버가 아직 옛 응답을 주므로 마무리 확인/목표 검증 화면이 나오지 않습니다 (앱이 죽지는 않습니다)
- 성격 선택 화면은 디자인 시안 없이 기존 화면(캐릭터 선택)의 레이아웃 패턴을 따라 만들었습니다. **시안이 나오면 조정이 필요합니다**
- 캐릭터 이름이 `characterId` 1=하루 / 2=나루로 프론트에 하드코딩돼 있습니다(`CurationChatViewModel`). 백엔드는 이제 DB 의 캐릭터 이름을 첫 질문 문구에 넣으므로 둘이 어긋날 수 있는데, 이번 범위에서는 건드리지 않았습니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)
